### PR TITLE
Update xdpfw.service

### DIFF
--- a/other/xdpfw.service
+++ b/other/xdpfw.service
@@ -5,6 +5,7 @@ Requires=network-online.target
 
 [Service]
 ExecStart=/usr/bin/xdpfw
+ExecStopPost=/bin/bash -c "ip link set dev $(grep -E ^interface /etc/xdpfw/xdpfw.conf | sed -En 's/^.+=|[\"; ]//gp') xdp off"
 Restart=always
 
 [Install]


### PR DESCRIPTION
Added ExecStopPost to unload xdp program from an interface after the service is stopped.

I tested it on Ubuntu 18.04 but I think it should work on other distrs too since those tools are common and I didn't use absolute paths (exept /bin/bash but it's should be present everywhere)  