### PR TITLE
strdup() mem leak fix

### DIFF
--- a/src/xdpfw.c
+++ b/src/xdpfw.c
@@ -514,7 +514,7 @@ int main(int argc, char *argv[])
         {
             // Memleak fix for strdup() in updateconfig()
             // Before updating it again, we need to free the old return value
-            free(cfg.interface)
+            free(cfg.interface);
 
             // Update config.
             updateconfig(&cfg, cmd.cfgfile);

--- a/src/xdpfw.c
+++ b/src/xdpfw.c
@@ -512,6 +512,10 @@ int main(int argc, char *argv[])
         // Check for auto-update.
         if (cfg.updatetime > 0 && (curTime - lastupdated) > cfg.updatetime)
         {
+            // Memleak fix for strdup() in updateconfig()
+            // Before updating it again, we need to free the old return value
+            free(cfg.interface)
+
             // Update config.
             updateconfig(&cfg, cmd.cfgfile);
 


### PR DESCRIPTION
After testing the code with this fix, it appears that the memory leak stops increasing with each update loop.