### PR TITLE
Pinning Maps, New CLI Utils, & IP Range Dropping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode/
 xdpfw
-xdpfw.s
-xdpfw.conf
+*.s
+*.conf
 *.log
 *.asm

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ sudo apt install -y libconfig-dev llvm clang libelf-dev build-essential
 # Install dependencies for building LibXDP and LibBPF.
 sudo apt install -y libpcap-dev m4 gcc-multilib
 
-# You may need tools for your Linux kernel since BPFTool is required. If this doesn't work and you still run into issues, I'd suggest building BPFTool from source (https://github.com/libbpf/bpftool).
+# You may need tools for your Linux kernel since BPFTool is required.
+# If this doesn't work and you still run into issues, I'd suggest building BPFTool from source (https://github.com/libbpf/bpftool).
 sudo apt install -y linux-tools-$(uname -r)
 ```
 
@@ -306,6 +307,10 @@ The following CLI arguments are supported.
 | Name | Example | Description |
 | ---- | ------- | ----------- |
 | -e, --expires | `-e 60` | When the source IP block expires in seconds when running in IP block list mode. |
+| --enabled | `--enabled 0` | Enables or disables dynamic filter. |
+| --action | `--action 1` | The action to perform on packets that match the filter (0 = drop, 1 = allow). |
+| --log | `--log 1` | Enables or disables logging for the dynamic filter. |
+| --block-time | `--block-time 60` | How long to block the source IP for if the packet is matched and the action is drop in the dynamic filter (0 = no time). | 
 | --sip | `--sip 192.168.1.0/24` | The source IPv4 address/range to match with the dynamic filter. |
 | --dip | `--sip 10.90.0.0/24` | The destination IPv4 address/range to match with the dynamic filter. |
 | --sip6 | `--sip 192.168.1.0/24` | The source IPv6 address to match with the dynamic filter. |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All features can be enabled or disabled through the build-time configuration ([`
 ### ⚡ Dynamic Filtering (Rule-Based)
 * Define **custom rules** to allow or drop packets based on protocols, ports, IP addresses, and more!
 * Supports **temporary bans** by adding IPs to the block list for a configurable duration.
-* Supports **TCP, UDP, and ICMP** network protocols and **IPv6**!
+* Supports **TCP, UDP, and ICMP** layer-4 protocols and **IPv6**!
 * Ideal for mitigating **non-spoofed (D)DoS attacks**.
 
 ### 🌍 IP Range Dropping (CIDR)

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Here's a runtime config example.
 verbose = 5;
 log_file = "";
 interface = "ens18";
+pin_maps = true;
 update_time = 15;
 no_stats = false;
 stats_per_second = true;
@@ -277,10 +278,12 @@ filters = (
         src_ip = "10.50.0.4"
     }
 );
+
+ip_drop_ranges = ( "192.168.1.0/24", "10.3.0.0/24" );
 ```
 
 ## 🔧 The `xdpfw-add` & `xdpfw-del` Utilities
-When the main BPF maps are pinned to the file system (depending on the `pin_maps` runtime option detailed above), this allows you to add or delete rules while the firewall is running using `xdpfw-add` and `xdpfw-del`.
+When the main BPF maps are pinned to the file system (depending on the `pin_maps` runtime option detailed above), this allows you to add or delete rules while the firewall is running using the `xdpfw-add` and `xdpfw-del` utilities.
 
 ### General CLI Usage
 The following general CLI arguments are supported with these utilities.

--- a/build/rule_add/.gitignore
+++ b/build/rule_add/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/build/rule_del/.gitignore
+++ b/build/rule_del/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -6,7 +6,7 @@
 
 // Enables IPv4 range drop map.
 // Disable this if you don't plan on adding IPv4 ranges to the drop map as it will increase performance.
-#define ENABLE_IP_RANGE_DROP
+//#define ENABLE_IP_RANGE_DROP
 
 // The maximum IP ranges supported in the IP range drop map.
 #define MAX_IP_RANGES 4096

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -1,5 +1,16 @@
 #pragma once
 
+// Enables dynamic filters.
+// Disable this for better performance if you only plan on adding entries to the block and drop maps.
+#define ENABLE_FILTERS
+
+// Enables IPv4 range drop map.
+// Disable this if you don't plan on adding IPv4 ranges to the drop map as it will increase performance.
+#define ENABLE_IP_RANGE_DROP
+
+// The maximum IP ranges supported in the IP range drop map.
+#define MAX_IP_RANGES 4096
+
 // The maximum amount of filters allowed.
 // Decrease this value if you receive errors related to the BPF program being too large.
 #define MAX_FILTERS 60
@@ -11,6 +22,9 @@
 // Feel free to comment this out if you don't want the `blocked` entry on the stats map to be incremented every single time a packet is dropped from the source IP being on the blocked map.
 // Commenting this line out should increase performance when blocking malicious traffic.
 #define DO_STATS_ON_BLOCK_MAP
+
+// Similar to DO_STATS_ON_BLOCK_MAP, but for IPv4 range drop map.
+#define DO_STATS_ON_IP_RANGE_DROP_MAP
 
 // When this is defined, a check will occur inside the IPv4 and IPv6 filters.
 // For IPv6 packets, if no IPv6 source/destination IP addresses are set, but there is an IPv4 address, it will ignore the filter.

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -153,3 +153,8 @@ struct filter_log_event
     u64 pps;
     u64 bps;
 } typedef filter_log_event_t;
+
+struct lpm_trie_key {
+    u32 prefix_len;
+    u32 data;
+} typedef LpmTrieKey;

--- a/src/loader/utils/cmdline.c
+++ b/src/loader/utils/cmdline.c
@@ -36,7 +36,7 @@ void ParseCommandLine(cmdline_t *cmd, int argc, char *argv[])
         switch (c)
         {
             case 'c':
-                cmd->cfgfile = optarg;
+                cmd->cfg_file = optarg;
 
                 break;
 

--- a/src/loader/utils/cmdline.c
+++ b/src/loader/utils/cmdline.c
@@ -12,6 +12,7 @@ const struct option opts[] =
     { "verbose", required_argument, NULL, 'v' },
     { "log-file", required_argument, NULL, 0 },
     { "interface", required_argument, NULL, 'i' },
+    { "pin-maps", required_argument, NULL, 'p' },
     { "update-time", required_argument, NULL, 'u' },
     { "no-stats", required_argument, NULL, 'n' },
     { "stats-ps", required_argument, NULL, 1 },
@@ -31,7 +32,7 @@ void ParseCommandLine(cmdline_t *cmd, int argc, char *argv[])
 {
     int c;
 
-    while ((c = getopt_long(argc, argv, "c:ost:lhv:i:u:n:", opts, NULL)) != -1)
+    while ((c = getopt_long(argc, argv, "c:ost:lhv:i:p:u:n:", opts, NULL)) != -1)
     {
         switch (c)
         {
@@ -77,6 +78,11 @@ void ParseCommandLine(cmdline_t *cmd, int argc, char *argv[])
 
             case 'i':
                 cmd->interface = optarg;
+
+                break;
+
+            case 'p':
+                cmd->pin_maps = atoi(optarg);
 
                 break;
 

--- a/src/loader/utils/cmdline.h
+++ b/src/loader/utils/cmdline.h
@@ -6,7 +6,7 @@
 
 struct cmdline
 {
-    char *cfgfile;
+    char *cfg_file;
     unsigned int offload : 1;
     unsigned int skb : 1;
     unsigned int time;

--- a/src/loader/utils/cmdline.h
+++ b/src/loader/utils/cmdline.h
@@ -16,6 +16,7 @@ struct cmdline
     int verbose;
     char* log_file;
     char* interface;
+    int pin_maps;
     int update_time;
     int no_stats;
     int stats_per_second;

--- a/src/loader/utils/config.c
+++ b/src/loader/utils/config.c
@@ -1,7 +1,5 @@
 #include <loader/utils/config.h>
 
-static FILE *file;
-
 /**
  * Loads the config from the file system.
  * 
@@ -13,105 +11,54 @@ static FILE *file;
  */
 int LoadConfig(config__t *cfg, char *cfg_file, config_overrides_t* overrides)
 {
+    int ret;
+    
+    FILE *file = NULL;
+    
     // Open config file.
-    if (OpenCfg(cfg_file) != 0)
+    if ((ret = OpenCfg(&file, cfg_file)) != 0 || file == NULL)
     {
         fprintf(stderr, "Error opening config file.\n");
         
-        return EXIT_FAILURE;
+        return ret;
     }
 
     SetCfgDefaults(cfg);
 
     memset(cfg->filters, 0, sizeof(cfg->filters));
 
-    // Read config and check for errors.
-    if (ReadCfg(cfg, overrides) != 0)
+    char* buffer = NULL;
+
+    // Read config.
+    if ((ret = ReadCfg(file, &buffer)) != 0)
     {
         fprintf(stderr, "Error reading config file.\n");
 
-        return EXIT_FAILURE;
+        CloseCfg(file);
+
+        return ret;
+    }
+
+    // Parse config.
+    if ((ret = ParseCfg(cfg, buffer, overrides)) != 0)
+    {
+        fprintf(stderr, "Error parsing config file.\n");
+
+        CloseCfg(file);
+
+        return ret;
+    }
+
+    free(buffer);
+
+    if ((ret = CloseCfg(file)) != 0)
+    {
+        fprintf(stderr, "Error closing config file.\n");
+
+        return ret;
     }
 
     return EXIT_SUCCESS;
-}
-
-/**
- * Sets the config structure's default values.
- * 
- * @param cfg A pointer to the config structure.
- * 
- * @return Void
- */
-void SetCfgDefaults(config__t *cfg)
-{
-    cfg->verbose = 2;
-    cfg->log_file = strdup("/var/log/xdpfw.log");
-    cfg->update_time = 0;
-    cfg->interface = NULL;
-    cfg->no_stats = 0;
-    cfg->stats_per_second = 0;
-    cfg->stdout_update_time = 1000;
-
-    for (int i = 0; i < MAX_FILTERS; i++)
-    {
-        filter_t* filter = &cfg->filters[i];
-
-        filter->set = 0;
-        filter->enabled = 1;
-
-        filter->log = 0;
-
-        filter->action = 1;
-        filter->src_ip = 0;
-        filter->dst_ip = 0;
-
-        memset(filter->src_ip6, 0, 4);
-        memset(filter->dst_ip6, 0, 4);
-
-        filter->do_min_len = 0;
-        filter->min_len = 0;
-
-        filter->do_max_len = 0;
-        filter->max_len = 65535;
-
-        filter->do_min_ttl = 0;
-        filter->min_ttl = 0;
-
-        filter->do_max_ttl = 0;
-        filter->max_ttl = 255;
-
-        filter->do_tos = 0;
-        filter->tos = 0;
-
-        filter->do_pps = 0;
-        filter->pps = 0;
-        
-        filter->do_bps = 0;
-        filter->bps = 0;
-
-        filter->block_time = 1;
-        
-        filter->tcpopts.enabled = 0;
-        filter->tcpopts.do_dport = 0;
-        filter->tcpopts.do_dport = 0;
-        filter->tcpopts.do_urg = 0;
-        filter->tcpopts.do_ack = 0;
-        filter->tcpopts.do_rst = 0;
-        filter->tcpopts.do_psh = 0;
-        filter->tcpopts.do_syn = 0;
-        filter->tcpopts.do_fin = 0;
-        filter->tcpopts.do_ece = 0;
-        filter->tcpopts.do_cwr = 0;
-
-        filter->udpopts.enabled = 0;
-        filter->udpopts.do_sport = 0;
-        filter->udpopts.do_dport = 0;
-
-        filter->icmpopts.enabled = 0;
-        filter->icmpopts.do_code = 0;
-        filter->icmpopts.do_type = 0;
-    }
 }
 
 /**
@@ -121,19 +68,19 @@ void SetCfgDefaults(config__t *cfg)
  * 
  * @return 0 on success or 1 on error.
  */
-int OpenCfg(const char *file_name)
+int OpenCfg(FILE** file, const char *file_name)
 {
     // Close any existing files.
-    if (file != NULL)
+    if (*file != NULL)
     {
-        fclose(file);
+        fclose(*file);
 
-        file = NULL;
+        *file = NULL;
     }
 
-    file = fopen(file_name, "r");
+    *file = fopen(file_name, "r");
 
-    if (file == NULL)
+    if (*file == NULL)
     {
         return 1;
     }
@@ -142,21 +89,58 @@ int OpenCfg(const char *file_name)
 }
 
 /**
+ * Close config file.
+ * 
+ * @param file A pointer to the file to close.
+ * 
+ * @param return 0 on success or error value of fclose().
+ */
+int CloseCfg(FILE* file)
+{
+    return fclose(file);
+}
+
+/**
+ * Reads contents from the config file.
+ * 
+ * @param file The file pointer.
+ * @param buffer The buffer to store the data in (manually allocated).
+ */
+int ReadCfg(FILE* file, char** buffer)
+{
+    fseek(file, 0, SEEK_END);
+    long file_size = ftell(file);
+    rewind(file);
+
+    if (file_size <= 0)
+    {
+        return 1;
+    }
+
+    *buffer = malloc(file_size + 1);
+
+    if (*buffer == NULL)
+    {
+        return 1;
+    }
+
+    size_t read = fread(*buffer, 1, file_size, file);
+    (*buffer)[read] = '\0';
+
+    return 0;
+}
+
+/**
  * Read the config file and stores values in config structure.
  * 
  * @param cfg A pointer to the config structure.
+ * @param data The config data.
  * @param overrides Overrides to use instead of config values.
  * 
  * @return 0 on success or 1/-1 on error.
  */
-int ReadCfg(config__t *cfg, config_overrides_t* overrides)
+int ParseCfg(config__t *cfg, const char* data, config_overrides_t* overrides)
 {
-    // Not sure why this would be set to NULL after checking for it in OpenConfig(), but just for safety.
-    if (file == NULL)
-    {
-        return -1;
-    }
-
     // Initialize config.
     config_t conf;
     config_setting_t *setting;
@@ -164,7 +148,7 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
     config_init(&conf);
 
     // Attempt to read the config.
-    if (config_read(&conf, file) == CONFIG_FALSE)
+    if (config_read_string(&conf, data) == CONFIG_FALSE)
     {
         LogMsg(cfg, 0, 1, "Error from LibConfig when reading file - %s (Line %d)", config_error_text(&conf), config_error_line(&conf));
 
@@ -189,7 +173,7 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
 
     const char* log_file;
 
-    if (config_lookup_string(&conf, "log_file", &log_file) == CONFIG_TRUE || overrides->log_file != NULL)
+    if (config_lookup_string(&conf, "log_file", &log_file) == CONFIG_TRUE || (overrides && overrides->log_file != NULL))
     {
         // We must free previous value to prevent memory leak.
         if (cfg->log_file != NULL)
@@ -226,7 +210,7 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
     // Get interface.
     const char *interface;
 
-    if (config_lookup_string(&conf, "interface", &interface) == CONFIG_TRUE || overrides->interface != NULL)
+    if (config_lookup_string(&conf, "interface", &interface) == CONFIG_TRUE || (overrides && overrides->interface != NULL))
     {
         // We must free previous value to prevent memory leak.
         if (cfg->interface != NULL)
@@ -245,10 +229,25 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
         }
     }
 
+    // Pin BPF maps.
+    int pin_maps;
+
+    if (config_lookup_bool(&conf, "pin_maps", &pin_maps) == CONFIG_TRUE || (overrides && overrides->pin_maps > -1))
+    {
+        if (overrides->pin_maps > -1)
+        {
+            cfg->pin_maps = overrides->pin_maps;
+        }
+        else
+        {
+            cfg->pin_maps = pin_maps;
+        }
+    }
+
     // Get auto update time.
     int update_time;
 
-    if (config_lookup_int(&conf, "update_time", &update_time) == CONFIG_TRUE || overrides->update_time > -1)
+    if (config_lookup_int(&conf, "update_time", &update_time) == CONFIG_TRUE || (overrides && overrides->update_time > -1))
     {
         if (overrides->update_time > -1)
         {
@@ -263,7 +262,7 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
     // Get no stats.
     int no_stats;
 
-    if (config_lookup_bool(&conf, "no_stats", &no_stats) == CONFIG_TRUE || overrides->no_stats > -1)
+    if (config_lookup_bool(&conf, "no_stats", &no_stats) == CONFIG_TRUE || (overrides && overrides->no_stats > -1))
     {
         if (overrides->no_stats > -1)
         {
@@ -278,7 +277,7 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
     // Stats per second.
     int stats_per_second;
 
-    if (config_lookup_bool(&conf, "stats_per_second", &stats_per_second) == CONFIG_TRUE || overrides->stats_per_second > -1)
+    if (config_lookup_bool(&conf, "stats_per_second", &stats_per_second) == CONFIG_TRUE || (overrides && overrides->stats_per_second > -1))
     {
         if (overrides->stats_per_second > -1)
         {
@@ -293,7 +292,7 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
     // Get stdout update time.
     int stdout_update_time;
 
-    if (config_lookup_int(&conf, "stdout_update_time", &stdout_update_time) == CONFIG_TRUE || overrides->stdout_update_time > -1)
+    if (config_lookup_int(&conf, "stdout_update_time", &stdout_update_time) == CONFIG_TRUE || (overrides && overrides->stdout_update_time > -1))
     {
         if (overrides->stdout_update_time > -1)
         {
@@ -486,18 +485,18 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
         }
 
         // Source port.
-        long long tcpsport;
+        int tcpsport;
 
-        if (config_setting_lookup_int64(filter_cfg, "tcp_sport", &tcpsport) == CONFIG_TRUE)
+        if (config_setting_lookup_int(filter_cfg, "tcp_sport", &tcpsport) == CONFIG_TRUE)
         {
             filter->tcpopts.sport = (u16)tcpsport;
             filter->tcpopts.do_sport = 1;
         }
 
         // Destination port.
-        long long tcpdport;
+        int tcpdport;
 
-        if (config_setting_lookup_int64(filter_cfg, "tcp_dport", &tcpdport) == CONFIG_TRUE)
+        if (config_setting_lookup_int(filter_cfg, "tcp_dport", &tcpdport) == CONFIG_TRUE)
         {
             filter->tcpopts.dport = (u16)tcpdport;
             filter->tcpopts.do_dport = 1;
@@ -521,7 +520,6 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
             filter->tcpopts.do_ack = 1;
         }
         
-
         // RST flag.
         int tcprst;
 
@@ -586,18 +584,18 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
         }
 
         // Source port.
-        long long udpsport;
+        int udpsport;
 
-        if (config_setting_lookup_int64(filter_cfg, "udp_sport", &udpsport) == CONFIG_TRUE)
+        if (config_setting_lookup_int(filter_cfg, "udp_sport", &udpsport) == CONFIG_TRUE)
         {
             filter->udpopts.sport = (u16)udpsport;
             filter->udpopts.do_sport = 1;
         }
 
         // Destination port.
-        long long udpdport;
+        int udpdport;
 
-        if (config_setting_lookup_int64(filter_cfg, "udp_dport", &udpdport) == CONFIG_TRUE)
+        if (config_setting_lookup_int(filter_cfg, "udp_dport", &udpdport) == CONFIG_TRUE)
         {
             filter->udpopts.dport = (u16)udpdport;
             filter->udpopts.do_dport = 1;
@@ -640,6 +638,430 @@ int ReadCfg(config__t *cfg, config_overrides_t* overrides)
 }
 
 /**
+ * Saves config to file system.
+ * 
+ * @param cfg A pointer to the config.
+ * @param file_path The file path to store the config into.
+ * 
+ * @param return 0 on success or 1 on failure.
+ */
+int SaveCfg(config__t* cfg, const char* file_path)
+{
+    config_t conf;
+    config_setting_t *root, *setting;
+
+    FILE* file;
+
+    config_init(&conf);
+    root = config_root_setting(&conf);
+
+    // Add verbose.
+    setting = config_setting_add(root, "verbose", CONFIG_TYPE_INT);
+    config_setting_set_int(setting, cfg->verbose);
+
+    // Add log file.
+    if (cfg->log_file)
+    {
+        setting = config_setting_add(root, "log_file", CONFIG_TYPE_STRING);
+        config_setting_set_string(setting, cfg->log_file);
+    }
+
+    // Add interface.
+    if (cfg->interface)
+    {
+        setting = config_setting_add(root, "interface", CONFIG_TYPE_STRING);
+        config_setting_set_string(setting, cfg->interface);
+    }
+
+    // Add pin maps.
+    setting = config_setting_add(root, "pin_maps", CONFIG_TYPE_BOOL);
+    config_setting_set_bool(setting, cfg->pin_maps);
+
+    // Add update time.
+    setting = config_setting_add(root, "update_time", CONFIG_TYPE_INT);
+    config_setting_set_int(setting, cfg->update_time);
+
+    // Add no stats.
+    setting = config_setting_add(root, "no_stats", CONFIG_TYPE_BOOL);
+    config_setting_set_bool(setting, cfg->no_stats);
+
+    // Add stats per second.
+    setting = config_setting_add(root, "stats_per_second", CONFIG_TYPE_BOOL);
+    config_setting_set_bool(setting, cfg->stats_per_second);
+
+    // Add stdout update time.
+    setting = config_setting_add(root, "stdout_update_time", CONFIG_TYPE_INT);
+    config_setting_set_int(setting, cfg->stdout_update_time);
+
+    // Add filters.
+    config_setting_t* filters = config_setting_add(root, "filters", CONFIG_TYPE_LIST);
+
+    if (filters)
+    {
+        for (int i = 0; i < MAX_FILTERS; i++)
+        {
+            filter_t* filter = &cfg->filters[i];
+
+            if (!filter->set)
+            {
+                continue;
+            }
+
+            config_setting_t* filter_cfg = config_setting_add(filters, NULL, CONFIG_TYPE_GROUP);
+
+            if (filter_cfg)
+            {
+                // Add enabled setting.
+                config_setting_t* enabled = config_setting_add(filter_cfg, "enabled", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(enabled, filter->enabled);
+
+                // Add log setting.
+                config_setting_t* log = config_setting_add(filter_cfg, "log", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(log, filter->log);
+
+                // Add action setting.
+                config_setting_t* action = config_setting_add(filter_cfg, "action", CONFIG_TYPE_INT);
+                config_setting_set_int(action, filter->action);
+
+                // Add source IPv4.
+                if (filter->src_ip > 0)
+                {
+                    char ip_str[INET_ADDRSTRLEN];
+
+                    inet_ntop(AF_INET, &filter->src_ip, ip_str, sizeof(ip_str));
+
+                    char full_ip[INET_ADDRSTRLEN + 6];
+                    snprintf(full_ip, sizeof(full_ip), "%s/%d", ip_str, filter->src_cidr);
+
+                    config_setting_t* src_ip = config_setting_add(filter_cfg, "src_ip", CONFIG_TYPE_STRING);
+                    config_setting_set_string(src_ip, full_ip);
+                }
+
+                // Add destination IPv4.
+                if (filter->dst_ip > 0)
+                {
+                    char ip_str[INET_ADDRSTRLEN];
+
+                    inet_ntop(AF_INET, &filter->dst_ip, ip_str, sizeof(ip_str));
+
+                    char full_ip[INET_ADDRSTRLEN + 6];
+                    snprintf(full_ip, sizeof(full_ip), "%s/%d", ip_str, filter->src_cidr);
+
+                    config_setting_t* dst_ip = config_setting_add(filter_cfg, "dst_ip", CONFIG_TYPE_STRING);
+                    config_setting_set_string(dst_ip, full_ip);
+                }
+                
+                // Add source IPv6.
+                if (memcmp(filter->src_ip6, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) != 0)
+                {
+                    char ip_str[INET6_ADDRSTRLEN];
+
+                    inet_ntop(AF_INET, filter->src_ip6, ip_str, sizeof(ip_str));
+
+                    //char full_ip[INET6_ADDRSTRLEN + 6];
+                    //snprintf(full_ip, sizeof(full_ip), "%s/%d", ip_str, filter->src_cidr6);
+
+                    config_setting_t* src_ip6 = config_setting_add(filter_cfg, "src_ip6", CONFIG_TYPE_STRING);
+                    config_setting_set_string(src_ip6, ip_str);
+                }
+
+                // Add source IPv6.
+                if (memcmp(filter->dst_ip6, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) != 0)
+                {
+                    char ip_str[INET6_ADDRSTRLEN];
+
+                    inet_ntop(AF_INET, filter->dst_ip6, ip_str, sizeof(ip_str));
+
+                    //char full_ip[INET6_ADDRSTRLEN + 6];
+                    //snprintf(full_ip, sizeof(full_ip), "%s/%d", ip_str, filter->src_cidr6);
+
+                    config_setting_t* dst_ip6 = config_setting_add(filter_cfg, "dst_ip6", CONFIG_TYPE_STRING);
+                    config_setting_set_string(dst_ip6, ip_str);
+                }
+
+                // Add minimum TTL.
+                config_setting_t* min_ttl = config_setting_add(filter_cfg, "min_ttl", CONFIG_TYPE_INT);
+                config_setting_set_int(min_ttl, filter->min_ttl);
+
+                // Add maximum TTL.
+                config_setting_t* max_ttl = config_setting_add(filter_cfg, "max_ttl", CONFIG_TYPE_INT);
+                config_setting_set_int(max_ttl, filter->max_ttl);
+
+                // Add minimum length.
+                config_setting_t* min_len = config_setting_add(filter_cfg, "min_len", CONFIG_TYPE_INT);
+                config_setting_set_int(min_len, filter->min_len);
+
+                // Add maximum length.
+                config_setting_t* max_len = config_setting_add(filter_cfg, "max_len", CONFIG_TYPE_INT);
+                config_setting_set_int(max_len, filter->max_len);
+
+                // Add ToS.
+                config_setting_t* tos = config_setting_add(filter_cfg, "tos", CONFIG_TYPE_INT);
+                config_setting_set_int(tos, filter->tos);
+
+                // Add PPS.
+                config_setting_t* pps = config_setting_add(filter_cfg, "pps", CONFIG_TYPE_INT64);
+                config_setting_set_int64(pps, filter->pps);
+
+                // Add BPS.
+                config_setting_t* bps = config_setting_add(filter_cfg, "bps", CONFIG_TYPE_INT64);
+                config_setting_set_int64(bps, filter->bps);
+
+                // Add block time.
+                config_setting_t* block_time = config_setting_add(filter_cfg, "block_time", CONFIG_TYPE_INT64);
+                config_setting_set_int64(block_time, filter->block_time);
+
+                // Add TCP enabled.
+                config_setting_t* tcp_enabled = config_setting_add(filter_cfg, "tcp_enabled", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_enabled, filter->tcpopts.enabled);
+
+                // Add TCP source port.
+                config_setting_t* tcp_sport = config_setting_add(filter_cfg, "tcp_sport", CONFIG_TYPE_INT);
+                config_setting_set_int(tcp_sport, filter->tcpopts.sport);
+
+                // Add TCP destination port.
+                config_setting_t* tcp_dport = config_setting_add(filter_cfg, "tcp_dport", CONFIG_TYPE_INT);
+                config_setting_set_int(tcp_dport, filter->tcpopts.dport);
+
+                // Add TCP URG flag.
+                config_setting_t* tcp_urg = config_setting_add(filter_cfg, "tcp_urg", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_urg, filter->tcpopts.urg);
+
+                // Add TCP ACK flag.
+                config_setting_t* tcp_ack = config_setting_add(filter_cfg, "tcp_ack", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_ack, filter->tcpopts.ack);
+
+                // Add TCP RST flag.
+                config_setting_t* tcp_rst = config_setting_add(filter_cfg, "tcp_rst", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_rst, filter->tcpopts.rst);
+
+                // Add TCP PSH flag.
+                config_setting_t* tcp_psh = config_setting_add(filter_cfg, "tcp_psh", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_psh, filter->tcpopts.psh);
+
+                // Add TCP SYN flag.
+                config_setting_t* tcp_syn = config_setting_add(filter_cfg, "tcp_syn", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_syn, filter->tcpopts.syn);
+
+                // Add TCP FIN flag.
+                config_setting_t* tcp_fin = config_setting_add(filter_cfg, "tcp_fin", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_fin, filter->tcpopts.fin);
+
+                // Add TCP ECE flag.
+                config_setting_t* tcp_ece = config_setting_add(filter_cfg, "tcp_ece", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_ece, filter->tcpopts.ece);
+
+                // Add TCP CWR flag.
+                config_setting_t* tcp_cwr = config_setting_add(filter_cfg, "tcp_cwr", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(tcp_cwr, filter->tcpopts.cwr);
+
+                // Add UDP enabled.
+                config_setting_t* udp_enabled = config_setting_add(filter_cfg, "udp_enabled", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(udp_enabled, filter->udpopts.enabled);
+
+                // Add UDP source port.
+                config_setting_t* udp_sport = config_setting_add(filter_cfg, "udp_sport", CONFIG_TYPE_INT);
+                config_setting_set_int(udp_sport, filter->udpopts.sport);
+
+                // Add UDP destination port.
+                config_setting_t* udp_dport = config_setting_add(filter_cfg, "udp_dport", CONFIG_TYPE_INT);
+                config_setting_set_int(udp_dport, filter->udpopts.dport);
+
+                // Add ICMP enabled.
+                config_setting_t* icmp_enabled = config_setting_add(filter_cfg, "icmp_enabled", CONFIG_TYPE_BOOL);
+                config_setting_set_bool(icmp_enabled, filter->icmpopts.enabled);
+
+                // Add ICMP code.
+                config_setting_t* icmp_code = config_setting_add(filter_cfg, "icmp_code", CONFIG_TYPE_INT);
+                config_setting_set_int(icmp_code, filter->icmpopts.code);
+
+                // Add ICMP type.
+                config_setting_t* icmp_type = config_setting_add(filter_cfg, "icmp_type", CONFIG_TYPE_INT);
+                config_setting_set_int(icmp_type, filter->icmpopts.type);
+            }
+        }
+    }
+
+    // Write config to file.
+    file = fopen(file_path, "w");
+
+    if (!file)
+    {
+        config_destroy(&conf);
+
+        return 1;
+    }
+
+    config_write(&conf, file);
+
+    fclose(file);
+    config_destroy(&conf);
+
+    return 0;
+}
+
+/**
+ * Sets the config structure's default values.
+ * 
+ * @param cfg A pointer to the config structure.
+ * 
+ * @return Void
+ */
+void SetCfgDefaults(config__t *cfg)
+{
+    cfg->verbose = 2;
+    cfg->log_file = strdup("/var/log/xdpfw.log");
+    cfg->update_time = 0;
+    cfg->interface = NULL;
+    cfg->pin_maps = 1;
+    cfg->no_stats = 0;
+    cfg->stats_per_second = 0;
+    cfg->stdout_update_time = 1000;
+
+    for (int i = 0; i < MAX_FILTERS; i++)
+    {
+        filter_t* filter = &cfg->filters[i];
+
+        filter->set = 0;
+        filter->enabled = 1;
+
+        filter->log = 0;
+
+        filter->action = 1;
+        filter->src_ip = 0;
+        filter->dst_ip = 0;
+
+        memset(filter->src_ip6, 0, 4);
+        memset(filter->dst_ip6, 0, 4);
+
+        filter->do_min_len = 0;
+        filter->min_len = 0;
+
+        filter->do_max_len = 0;
+        filter->max_len = 65535;
+
+        filter->do_min_ttl = 0;
+        filter->min_ttl = 0;
+
+        filter->do_max_ttl = 0;
+        filter->max_ttl = 255;
+
+        filter->do_tos = 0;
+        filter->tos = 0;
+
+        filter->do_pps = 0;
+        filter->pps = 0;
+        
+        filter->do_bps = 0;
+        filter->bps = 0;
+
+        filter->block_time = 1;
+        
+        filter->tcpopts.enabled = 0;
+        filter->tcpopts.do_dport = 0;
+        filter->tcpopts.do_dport = 0;
+        filter->tcpopts.do_urg = 0;
+        filter->tcpopts.do_ack = 0;
+        filter->tcpopts.do_rst = 0;
+        filter->tcpopts.do_psh = 0;
+        filter->tcpopts.do_syn = 0;
+        filter->tcpopts.do_fin = 0;
+        filter->tcpopts.do_ece = 0;
+        filter->tcpopts.do_cwr = 0;
+
+        filter->udpopts.enabled = 0;
+        filter->udpopts.do_sport = 0;
+        filter->udpopts.do_dport = 0;
+
+        filter->icmpopts.enabled = 0;
+        filter->icmpopts.do_code = 0;
+        filter->icmpopts.do_type = 0;
+    }
+}
+
+/**
+ * Prints a filter rule.
+ * 
+ * @param filter A pointer to the filter rule.
+ * @param idx The current index.
+ * 
+ * @return void
+ */
+void PrintFilter(filter_t* filter, int idx)
+{
+    printf("\tFilter #%d\n", idx);
+    printf("\t\tEnabled => %d\n", filter->enabled);
+    printf("\t\tAction => %d (0 = Block, 1 = Allow).\n", filter->action);
+    printf("\t\tLog => %d\n\n", filter->log);
+
+    // IP Options.
+    printf("\t\tIP Options\n");
+
+    // IP addresses require additional code for string printing.
+    struct sockaddr_in sin;
+    sin.sin_addr.s_addr = filter->src_ip;
+    printf("\t\t\tSource IPv4 => %s\n", inet_ntoa(sin.sin_addr));
+    printf("\t\t\tSource CIDR => %d\n", filter->src_cidr);
+
+    struct sockaddr_in din;
+    din.sin_addr.s_addr = filter->dst_ip;
+    printf("\t\t\tDestination IPv4 => %s\n", inet_ntoa(din.sin_addr));
+    printf("\t\t\tDestination CIDR => %d\n", filter->dst_cidr);
+
+    struct in6_addr sin6;
+    memcpy(&sin6, &filter->src_ip6, sizeof(sin6));
+    
+    char srcipv6[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, &sin6, srcipv6, sizeof(srcipv6));
+
+    printf("\t\t\tSource IPv6 => %s\n", srcipv6);
+
+    struct in6_addr din6;
+    memcpy(&din6, &filter->dst_ip6, sizeof(din6));
+
+    char dstipv6[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, &din6, dstipv6, sizeof(dstipv6));
+
+    printf("\t\t\tDestination IPv6 => %s\n", dstipv6);
+
+    // Other IP header information.
+    printf("\t\t\tMax Length => %d\n", filter->max_len);
+    printf("\t\t\tMin Length => %d\n", filter->min_len);
+    printf("\t\t\tMax TTL => %d\n", filter->max_ttl);
+    printf("\t\t\tMin TTL => %d\n", filter->min_ttl);
+    printf("\t\t\tTOS => %d\n", filter->tos);
+    printf("\t\t\tPPS => %llu\n", filter->pps);
+    printf("\t\t\tBPS => %llu\n", filter->bps);
+    printf("\t\t\tBlock Time => %llu\n\n", filter->block_time);
+
+    // TCP Options.
+    printf("\t\tTCP Options\n");
+    printf("\t\t\tTCP Enabled => %d\n", filter->tcpopts.enabled);
+    printf("\t\t\tTCP Source Port => %d\n", filter->tcpopts.sport);
+    printf("\t\t\tTCP Destination Port => %d\n", filter->tcpopts.dport);
+    printf("\t\t\tTCP URG Flag => %d\n", filter->tcpopts.urg);
+    printf("\t\t\tTCP ACK Flag => %d\n", filter->tcpopts.ack);
+    printf("\t\t\tTCP RST Flag => %d\n", filter->tcpopts.rst);
+    printf("\t\t\tTCP PSH Flag => %d\n", filter->tcpopts.psh);
+    printf("\t\t\tTCP SYN Flag => %d\n", filter->tcpopts.syn);
+    printf("\t\t\tTCP FIN Flag => %d\n", filter->tcpopts.fin);
+    printf("\t\t\tTCP ECE Flag => %d\n", filter->tcpopts.ece);
+    printf("\t\t\tTCP CWR Flag => %d\n\n", filter->tcpopts.cwr);
+
+    // UDP Options.
+    printf("\t\tUDP Options\n");
+    printf("\t\t\tUDP Enabled => %d\n", filter->udpopts.enabled);
+    printf("\t\t\tUDP Source Port => %d\n", filter->udpopts.sport);
+    printf("\t\t\tUDP Destination Port => %d\n\n", filter->udpopts.dport);
+
+    // ICMP Options.
+    printf("\t\tICMP Options\n");
+    printf("\t\t\tICMP Enabled => %d\n", filter->icmpopts.enabled);
+    printf("\t\t\tICMP Code => %d\n", filter->icmpopts.code);
+    printf("\t\t\tICMP Type => %d\n", filter->icmpopts.type);
+}
+
+/**
  * Prints config settings.
  * 
  * @param cfg A pointer to the config structure.
@@ -663,17 +1085,18 @@ void PrintConfig(config__t* cfg)
     }
 
     printf("Printing config...\n");
-    printf("\tGeneral Settings\n");
+    printf("General Settings\n");
     
-    printf("\t\tVerbose => %d\n", cfg->verbose);
-    printf("\t\tLog File => %s\n", log_file);
-    printf("\t\tInterface Name => %s\n", interface);
-    printf("\t\tUpdate Time => %d\n", cfg->update_time);
-    printf("\t\tNo Stats => %d\n", cfg->no_stats);
-    printf("\t\tStats Per Second => %d\n", cfg->stats_per_second);
-    printf("\t\tStdout Update Time => %d\n\n", cfg->stdout_update_time);
+    printf("\tVerbose => %d\n", cfg->verbose);
+    printf("\tLog File => %s\n", log_file);
+    printf("\tInterface Name => %s\n", interface);
+    printf("\tPin BPF Maps => %d\n", cfg->pin_maps);
+    printf("\tUpdate Time => %d\n", cfg->update_time);
+    printf("\tNo Stats => %d\n", cfg->no_stats);
+    printf("\tStats Per Second => %d\n", cfg->stats_per_second);
+    printf("\tStdout Update Time => %d\n\n", cfg->stdout_update_time);
 
-    printf("\tFilters\n");
+    printf("Filters\n");
 
     for (int i = 0; i < MAX_FILTERS; i++)
     {
@@ -684,79 +1107,32 @@ void PrintConfig(config__t* cfg)
             break;
         }
 
-        printf("\t\tFilter #%d:\n", (i + 1));
-
-        // Main.
-        printf("\t\t\tEnabled => %d\n", filter->enabled);
-        printf("\t\t\tAction => %d (0 = Block, 1 = Allow).\n", filter->action);
-        printf("\t\t\tLog => %d\n\n", filter->log);
-
-        // IP Options.
-        printf("\t\t\tIP Options\n");
-
-        // IP addresses require additional code for string printing.
-        struct sockaddr_in sin;
-        sin.sin_addr.s_addr = filter->src_ip;
-        printf("\t\t\t\tSource IPv4 => %s\n", inet_ntoa(sin.sin_addr));
-        printf("\t\t\t\tSource CIDR => %d\n", filter->src_cidr);
-
-        struct sockaddr_in din;
-        din.sin_addr.s_addr = filter->dst_ip;
-        printf("\t\t\t\tDestination IPv4 => %s\n", inet_ntoa(din.sin_addr));
-        printf("\t\t\t\tDestination CIDR => %d\n", filter->dst_cidr);
-
-        struct in6_addr sin6;
-        memcpy(&sin6, &filter->src_ip6, sizeof(sin6));
-        
-        char srcipv6[INET6_ADDRSTRLEN];
-        inet_ntop(AF_INET6, &sin6, srcipv6, sizeof(srcipv6));
-
-        printf("\t\t\t\tSource IPv6 => %s\n", srcipv6);
-
-        struct in6_addr din6;
-        memcpy(&din6, &filter->dst_ip6, sizeof(din6));
-
-        char dstipv6[INET6_ADDRSTRLEN];
-        inet_ntop(AF_INET6, &din6, dstipv6, sizeof(dstipv6));
-
-        printf("\t\t\t\tDestination IPv6 => %s\n", dstipv6);
-
-        // Other IP header information.
-        printf("\t\t\t\tMax Length => %d\n", filter->max_len);
-        printf("\t\t\t\tMin Length => %d\n", filter->min_len);
-        printf("\t\t\t\tMax TTL => %d\n", filter->max_ttl);
-        printf("\t\t\t\tMin TTL => %d\n", filter->min_ttl);
-        printf("\t\t\t\tTOS => %d\n", filter->tos);
-        printf("\t\t\t\tPPS => %llu\n", filter->pps);
-        printf("\t\t\t\tBPS => %llu\n", filter->bps);
-        printf("\t\t\t\tBlock Time => %llu\n\n", filter->block_time);
-
-        // TCP Options.
-        printf("\t\t\tTCP Options\n");
-        printf("\t\t\t\tTCP Enabled => %d\n", filter->tcpopts.enabled);
-        printf("\t\t\t\tTCP Source Port => %d\n", filter->tcpopts.sport);
-        printf("\t\t\t\tTCP Destination Port => %d\n", filter->tcpopts.dport);
-        printf("\t\t\t\tTCP URG Flag => %d\n", filter->tcpopts.urg);
-        printf("\t\t\t\tTCP ACK Flag => %d\n", filter->tcpopts.ack);
-        printf("\t\t\t\tTCP RST Flag => %d\n", filter->tcpopts.rst);
-        printf("\t\t\t\tTCP PSH Flag => %d\n", filter->tcpopts.psh);
-        printf("\t\t\t\tTCP SYN Flag => %d\n", filter->tcpopts.syn);
-        printf("\t\t\t\tTCP FIN Flag => %d\n", filter->tcpopts.fin);
-        printf("\t\t\t\tTCP ECE Flag => %d\n", filter->tcpopts.ece);
-        printf("\t\t\t\tTCP CWR Flag => %d\n\n", filter->tcpopts.cwr);
-
-        // UDP Options.
-        printf("\t\t\tUDP Options\n");
-        printf("\t\t\t\tUDP Enabled => %d\n", filter->udpopts.enabled);
-        printf("\t\t\t\tUDP Source Port => %d\n", filter->udpopts.sport);
-        printf("\t\t\t\tUDP Destination Port => %d\n\n", filter->udpopts.dport);
-
-        // ICMP Options.
-        printf("\t\t\tICMP Options\n");
-        printf("\t\t\t\tICMP Enabled => %d\n", filter->icmpopts.enabled);
-        printf("\t\t\t\tICMP Code => %d\n", filter->icmpopts.code);
-        printf("\t\t\t\tICMP Type => %d\n", filter->icmpopts.type);
+        PrintFilter(filter, i + 1);
 
         printf("\n\n");
     }
+}
+
+/**
+ * Retrieves next available filter index.
+ * 
+ * @param cfg A pointer to the config structure.
+ * 
+ * @return The next available index or -1 if there are no available indexes.
+ */
+int GetNextAvailableFilterIndex(config__t* cfg)
+{
+    for (int i = 0; i < MAX_FILTERS; i++)
+    {
+        filter_t* filter = &cfg->filters[i];
+
+        if (filter->set)
+        {
+            continue;
+        }
+
+        return i;
+    }
+
+    return -1;
 }

--- a/src/loader/utils/config.h
+++ b/src/loader/utils/config.h
@@ -18,6 +18,7 @@ struct config
     int verbose;
     char *log_file;
     char *interface;
+    unsigned int pin_maps : 1;
     int update_time;
     unsigned int no_stats : 1;
     unsigned int stats_per_second : 1;
@@ -30,6 +31,7 @@ struct config_overrides
     int verbose;
     const char* log_file;
     const char* interface;
+    int pin_maps;
     int update_time;
     int no_stats;
     int stats_per_second;
@@ -37,11 +39,19 @@ struct config_overrides
     
 } typedef config_overrides_t;
 
-int LoadConfig(config__t *cfg, char *cfg_file, config_overrides_t* overrides);
 void SetCfgDefaults(config__t *cfg);
+
+void PrintFilter(filter_t* filter, int idx);
 void PrintConfig(config__t* cfg);
 
-int OpenCfg(const char *filename);
-int ReadCfg(config__t *cfg, config_overrides_t* overrides);
+int LoadConfig(config__t *cfg, char *cfg_file, config_overrides_t* overrides);
+int SaveCfg(config__t* cfg, const char* file_path);
+
+int OpenCfg(FILE** file, const char *file_name);
+int CloseCfg(FILE* file);
+int ReadCfg(FILE* file, char** buffer);
+int ParseCfg(config__t *cfg, const char* data, config_overrides_t* overrides);
+
+int GetNextAvailableFilterIndex(config__t* cfg);
 
 #include <loader/utils/logging.h>

--- a/src/loader/utils/config.h
+++ b/src/loader/utils/config.h
@@ -23,7 +23,9 @@ struct config
     unsigned int no_stats : 1;
     unsigned int stats_per_second : 1;
     int stdout_update_time;
+
     filter_t filters[MAX_FILTERS];
+    const char* drop_ranges[MAX_IP_RANGES];
 } typedef config__t; // config_t is taken by libconfig -.-
 
 struct config_overrides
@@ -36,15 +38,15 @@ struct config_overrides
     int no_stats;
     int stats_per_second;
     int stdout_update_time;
-    
 } typedef config_overrides_t;
 
 void SetCfgDefaults(config__t *cfg);
+void SetFilterDefaults(filter_t* filter);
 
-void PrintFilter(filter_t* filter, int idx);
 void PrintConfig(config__t* cfg);
+void PrintFilter(filter_t* filter, int idx);
 
-int LoadConfig(config__t *cfg, char *cfg_file, config_overrides_t* overrides);
+int LoadConfig(config__t *cfg, const char* cfg_file, config_overrides_t* overrides);
 int SaveCfg(config__t* cfg, const char* file_path);
 
 int OpenCfg(FILE** file, const char *file_name);
@@ -53,5 +55,6 @@ int ReadCfg(FILE* file, char** buffer);
 int ParseCfg(config__t *cfg, const char* data, config_overrides_t* overrides);
 
 int GetNextAvailableFilterIndex(config__t* cfg);
+int GetNextAvailableIpDropRangeIndex(config__t* cfg);
 
 #include <loader/utils/logging.h>

--- a/src/loader/utils/helpers.c
+++ b/src/loader/utils/helpers.c
@@ -113,7 +113,7 @@ void PrintToolInfo()
 /**
  * Retrieves nanoseconds since system boot.
  * 
- * @return The current nanoseconds since the system started.
+ * @return The current nanoseconds since the system last booted.
  */
 u64 GetBootNanoTime()
 {

--- a/src/loader/utils/helpers.c
+++ b/src/loader/utils/helpers.c
@@ -48,7 +48,11 @@ ip_range_t ParseIpCidr(const char *ip)
     ip_range_t ret = {0};
     ret.cidr = 32;
 
-    char *token = strtok((char *) ip, "/");
+    char ip_copy[INET_ADDRSTRLEN + 3];
+    strncpy(ip_copy, ip, sizeof(ip_copy) - 1);
+    ip_copy[sizeof(ip_copy) - 1] = '\0';
+
+    char *token = strtok((char *) ip_copy, "/");
 
     if (token)
     {
@@ -104,4 +108,17 @@ void PrintToolInfo()
         " /_/\\_\\____/|_|     |_|   |_|_|  \\___| \\_/\\_/ \\__,_|_|_|\n"
         "\n\n"
     );
+}
+
+/**
+ * Retrieves nanoseconds since system boot.
+ * 
+ * @return The current nanoseconds since the system started.
+ */
+u64 GetBootNanoTime()
+{
+    struct sysinfo sys;
+    sysinfo(&sys);
+
+    return sys.uptime * 1e9;
 }

--- a/src/loader/utils/helpers.h
+++ b/src/loader/utils/helpers.h
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <sys/sysinfo.h>
+
 struct ip_range
 {
     u32 ip;
@@ -20,3 +22,4 @@ void SignalHndl(int code);
 ip_range_t ParseIpCidr(const char* ip);
 const char* GetProtocolStrById(int id);
 void PrintToolInfo();
+u64 GetBootNanoTime();

--- a/src/loader/utils/logging.c
+++ b/src/loader/utils/logging.c
@@ -74,7 +74,6 @@ static void LogMsgRaw(int req_lvl, int cur_lvl, int error, const char* log_path,
             return;
         }
 
-
         char log_file_msg[len + 22 + 1];
 
         snprintf(log_file_msg, sizeof(log_file_msg), "[%02d-%02d-%02d %02d:%02d:%02d]%s", tm_val->tm_year % 100, tm_val->tm_mon + 1, tm_val->tm_mday,
@@ -143,7 +142,7 @@ int HandleRbEvent(void* ctx, void* data, size_t sz)
     }
 
     char src_ip_str[INET6_ADDRSTRLEN];
-    char dst_ip_str[INET_ADDRSTRLEN];
+    char dst_ip_str[INET6_ADDRSTRLEN];
 
     if (memcmp(e->src_ip6, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16) != 0)
     {

--- a/src/loader/utils/stats.c
+++ b/src/loader/utils/stats.c
@@ -53,7 +53,8 @@ int CalculateStats(int map_stats, int cpus, int per_second)
     if (per_second)
     {
         struct timespec now;
-        clock_gettime(CLOCK_MONOTONIC, &now);  // Get precise time
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        
         double elapsed_time = (now.tv_sec - last_update_time.tv_sec) +
                               (now.tv_nsec - last_update_time.tv_nsec) / 1e9; 
 

--- a/src/loader/utils/stats.h
+++ b/src/loader/utils/stats.h
@@ -4,7 +4,6 @@
 
 #include <common/all.h>
 
-#include <loader/utils/cmdline.h>
 #include <loader/utils/config.h>
 #include <loader/utils/helpers.h>
 

--- a/src/loader/utils/xdp.c
+++ b/src/loader/utils/xdp.c
@@ -86,17 +86,30 @@ struct xdp_program *LoadBpfObj(const char *file_name)
 }
 
 /**
+ * Retrieves BPF object from XDP program.
+ * 
+ * @param prog A pointer to the XDP program.
+ * 
+ * @return The BPF object.
+ */
+struct bpf_object* GetBpfObj(struct xdp_program* prog)
+{
+    return xdp_program__bpf_obj(prog);
+}
+
+/**
  * Attempts to attach or detach (progfd = -1) a BPF/XDP program to an interface.
  * 
  * @param prog A pointer to the XDP program structure.
  * @param mode_used The mode being used.
  * @param ifidx The index to the interface to attach to.
  * @param detach If above 0, attempts to detach XDP program.
- * @param cmd A pointer to a cmdline struct that includes command line arguments (mostly checking for offload/HW mode set).
+ * @param force_skb If set, forces the XDP program to run in SKB mode.
+ * @param force_offload If set, forces the XDP program to run in offload mode.
  * 
  * @return 0 on success and 1 on error.
  */
-int AttachXdp(struct xdp_program *prog, char** mode, int ifidx, u8 detach, cmdline_t *cmd)
+int AttachXdp(struct xdp_program *prog, char** mode, int ifidx, int detach, int force_skb, int force_offload)
 {
     int err;
 
@@ -104,13 +117,13 @@ int AttachXdp(struct xdp_program *prog, char** mode, int ifidx, u8 detach, cmdli
 
     *mode = "DRV/native";
 
-    if (cmd->offload)
+    if (force_offload)
     {
         *mode = "HW/offload";
 
         attach_mode = XDP_MODE_HW;
     }
-    else if (cmd->skb)
+    else if (force_skb)
     {
         *mode = "SKB/generic";
         
@@ -177,6 +190,58 @@ int AttachXdp(struct xdp_program *prog, char** mode, int ifidx, u8 detach, cmdli
 }
 
 /**
+ * Deletes a filter.
+ * 
+ * @param map_filters The filters BPF map FD.
+ * @param idx The filter index to delete.
+ * 
+ * @return 0 on success or the error value of bpf_map_delete_elem().
+ */
+int DeleteFilter(int map_filters, u32 idx)
+{
+    return bpf_map_delete_elem(map_filters, &idx);
+}
+
+/**
+ * Deletes all filters.
+ * 
+ * @param map_filters The filters BPF map FD.
+ * 
+ * @return void
+ */
+void DeleteFilters(int map_filters)
+{
+    for (int i = 0; i < MAX_FILTERS; i++)
+    {
+        DeleteFilter(map_filters, i);
+    }
+}
+
+/**
+ * Updates a filter rule.
+ * 
+ * @param map_filters The filters BPF map FD.
+ * @param filter A pointer to the filter.
+ * @param idx The filter index to insert or update.
+ * 
+ * @return 0 on success or error value of bpf_map_update_elem().
+ */
+int UpdateFilter(int map_filters, filter_t* filter, int idx)
+{
+    int ret;
+
+    filter_t filter_cpus[MAX_CPUS];
+    memset(filter_cpus, 0, sizeof(filter_cpus));
+
+    for (int j = 0; j < MAX_CPUS; j++)
+    {
+        filter_cpus[j] = *filter;
+    }
+
+    return bpf_map_update_elem(map_filters, &idx, &filter_cpus, BPF_ANY);
+}
+
+/**
  * Updates the filter's BPF map with current config settings.
  * 
  * @param map_filters The filter's BPF map FD.
@@ -192,13 +257,11 @@ void UpdateFilters(int map_filters, config__t *cfg)
     // Add a filter to the filter maps.
     for (int i = 0; i < MAX_FILTERS; i++)
     {
-        filter_t* filter = &cfg->filters[i];
-
         // Delete previous rule from BPF map.
         // We do this in the case rules were edited and were put out of order since the key doesn't uniquely map to a specific rule.
-        u32 key = i;
+        DeleteFilter(map_filters, i);
 
-        bpf_map_delete_elem(map_filters, &key);
+        filter_t* filter = &cfg->filters[i];
 
         // Only insert set and enabled filters.
         if (!filter->set || !filter->enabled)
@@ -206,21 +269,78 @@ void UpdateFilters(int map_filters, config__t *cfg)
             continue;
         }
 
-        // Create value array (max CPUs in size) since we're using a per CPU map.
-        filter_t filter_cpus[MAX_CPUS];
-        memset(filter_cpus, 0, sizeof(filter_cpus));
-
-        for (int j = 0; j < MAX_CPUS; j++)
+        // Attempt to update filter.
+        if ((ret = UpdateFilter(map_filters, filter, cur_idx)) != 0)
         {
-            filter_cpus[j] = *filter;
-        }
+            fprintf(stderr, "[WARNING] Failed to update filter #%d due to BPF update error (%d)...\n", cur_idx, ret);
 
-        // Attempt to update BPF map.
-        if ((ret = bpf_map_update_elem(map_filters, &cur_idx, &filter_cpus, BPF_ANY)) != 0)
-        {
-            fprintf(stderr, "[WARNING] Failed to update filter #%d due to BPF update error (%d)...\n", i, ret);
+            continue;
         }
 
         cur_idx++;
     }
+}
+
+/**
+ * Pins a BPF map to the file system.
+ * 
+ * @param obj A pointer to the BPF object.
+ * @param pin_dir The pin directory.
+ * @param map_name The map name.
+ * 
+ * @return 0 on success or value of bpf_map__pin() on error.
+ */
+int PinBpfMap(struct bpf_object* obj, const char* pin_dir, const char* map_name)
+{
+    struct bpf_map* map = bpf_object__find_map_by_name(obj, map_name);
+
+    if (!map)
+    {
+        return -1;
+    }
+
+    char full_path[255];
+    snprintf(full_path, sizeof(full_path), "%s/%s", XDP_MAP_PIN_DIR, map_name);
+
+    return bpf_map__pin(map, full_path);
+}
+
+/**
+ * Unpins a BPF map from the file system.
+ * 
+ * @param obj A pointer to the BPF object.
+ * @param pin_dir The pin directory.
+ * @param map_name The map name.
+ * 
+ * @return
+ */
+int UnpinBpfMap(struct bpf_object* obj, const char* pin_dir, const char* map_name)
+{
+    struct bpf_map* map = bpf_object__find_map_by_name(obj, map_name);
+
+    if (!map)
+    {
+        return 1;
+    }
+
+    char full_path[255];
+    snprintf(full_path, sizeof(full_path), "%s/%s", XDP_MAP_PIN_DIR, map_name);
+
+    return bpf_map__unpin(map, full_path);
+}
+
+/**
+ * Retrieves a map FD on the file system (pinned).
+ * 
+ * @param pin_dir The pin directory.
+ * @param map_name The map name.
+ * 
+ * @return The map FD or -1 on error.
+ */
+int GetMapPinFd(const char* pin_dir, const char* map_name)
+{
+    char full_path[255];
+    snprintf(full_path, sizeof(full_path), "%s/%s", pin_dir, map_name);
+
+    return bpf_obj_get(full_path);
 }

--- a/src/loader/utils/xdp.h
+++ b/src/loader/utils/xdp.h
@@ -27,3 +27,13 @@ void UpdateFilters(int map_filters, config__t *cfg);
 int PinBpfMap(struct bpf_object* obj, const char* pin_dir, const char* map_name);
 int UnpinBpfMap(struct bpf_object* obj, const char* pin_dir, const char* map_name);
 int GetMapPinFd(const char* pin_dir, const char* map_name);
+
+int DeleteBlock(int map_block, u32 ip);
+int AddBlock(int map_block, u32 ip, u64 expires);
+
+int DeleteBlock6(int map_block6, u128 ip);
+int AddBlock6(int map_block6, u128 ip, u64 expires);
+
+int DeleteRangeDrop(int map_range_drop, u32 net, u8 cidr);
+int AddRangeDrop(int map_range_drop, u32 net, u8 cidr);
+void UpdateRangeDrops(int map_range_drop, config__t* cfg);

--- a/src/loader/utils/xdp.h
+++ b/src/loader/utils/xdp.h
@@ -4,14 +4,26 @@
 
 #include  <common/all.h>
 
-#include <loader/utils/cmdline.h>
 #include <loader/utils/config.h>
 #include <loader/utils/helpers.h>
 
 #define XDP_OBJ_PATH "/etc/xdpfw/xdp_prog.o"
+#define XDP_MAP_PIN_DIR "/sys/fs/bpf/xdpfw"
 
 int FindMapFd(struct xdp_program *prog, const char *map_name);
 void SetLibBPFLogMode(int silent);
+
 struct xdp_program *LoadBpfObj(const char *file_name);
-int AttachXdp(struct xdp_program *prog, char** mode, int ifidx, u8 detach, cmdline_t *cmd);
+struct bpf_object* GetBpfObj(struct xdp_program* prog);
+
+int AttachXdp(struct xdp_program *prog, char** mode, int ifidx, int detach, int force_skb, int force_offload);
+
+int DeleteFilter(int map_filters, u32 idx);
+void DeleteFilters(int map_filters);
+
+int UpdateFilter(int map_filters, filter_t* filter, int idx);
 void UpdateFilters(int map_filters, config__t *cfg);
+
+int PinBpfMap(struct bpf_object* obj, const char* pin_dir, const char* map_name);
+int UnpinBpfMap(struct bpf_object* obj, const char* pin_dir, const char* map_name);
+int GetMapPinFd(const char* pin_dir, const char* map_name);

--- a/src/rule_add/prog.c
+++ b/src/rule_add/prog.c
@@ -1,0 +1,506 @@
+#include <common/all.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <loader/utils/xdp.h>
+#include <loader/utils/config.h>
+
+#include <rule_add/utils/cmdline.h>
+
+// These are required due to being extern with Loader.
+// To Do: Figure out a way to not require the below without requiring separate object files.
+int cont = 0;
+int doing_stats = 0;
+
+int main(int argc, char *argv[])
+{
+    int ret;
+
+    // Parse command line.
+    cmdline_t cmd = {0};
+    cmd.cfg_file = CONFIG_DEFAULT_PATH;
+
+    ParseCommandLine(&cmd, argc, argv);
+
+    if (!cmd.help)
+    {
+        printf("Parsed command line...\n");
+    }
+    else
+    {
+        printf("Usage: xdpfw-add [OPTIONS]\n\n");
+
+        printf("OPTIONS:\n");
+        printf("  -c, --cfg         The path to the config file (default /etc/xdpfw/xdpfw.conf).\n");
+        printf("  -s, --save        Saves the new config to file system.\n");
+        printf("  -m, --mode        The mode to use (0 = filters, 1 = IPv4 range drop, 2 = IP block map).\n");
+        printf("  -i, --idx         The filters index to update when using filters mode (0) (index starts from 1; retrieve index using xdpfw -l).\n");
+        printf("  -d, --ip          The IP range or single IP to add (for modes 1 and 2).\n");
+        printf("  -v, --v6          If set, parses IP address as IPv6 when adding to block map (for mode 2).\n");
+        printf("  -e, --expires     How long to block the IP for in seconds (for mode 2).\n\n");
+
+        printf("Filter Mode Options:\n");
+        printf("  --sip             The source IPv4 address (with CIDR support).\n");
+        printf("  --dip             The destination IPv4 address (with CIDR support).\n");
+        printf("  --sip6            The source IPv6 address.\n");
+        printf("  --dip6            The destination IPv6 address.\n");
+        printf("  --min-ttl         The minimum IP TTL to match.\n");
+        printf("  --max-ttl         The maximum IP TTL to match.\n");
+        printf("  --min-len         The minimum packet length to match.\n");
+        printf("  --max-len         The maximum packet length to match.\n");
+        printf("  --tos             The IP Type of Service to match.\n\n");
+
+        printf("  --pps             The minimum packet rate (per second) to match.\n");
+        printf("  --bps             The minimum byte rate (per second) to match\n\n");
+        
+        printf("  --tcp             Enable or disables matching on the TCP protocol.\n");
+        printf("  --tsport          The TCP source port to match on.\n");
+        printf("  --tdport          The TCP destination port to match on.\n");
+        printf("  --urg             Enables or disables matching on TCP URG flag.\n");
+        printf("  --ack             Enables or disables matching on TCP ACK flag.\n");
+        printf("  --rst             Enables or disables matching on TCP RST flag.\n");
+        printf("  --psh             Enables or disables matching on TCP PSH flag.\n");
+        printf("  --syn             Enables or disables matching on TCP SYN flag.\n");
+        printf("  --fin             Enables or disables matching on TCP FIN flag.\n");
+        printf("  --ece             Enables or disables matching on TCP ECE flag.\n");
+        printf("  --cwr             Enables or disables matching on TCP CWR flag.\n\n");
+
+        printf("  --udp             Enable or disables matching on the UDP protocol.\n");
+        printf("  --usport          The UDP source port to match on.\n");
+        printf("  --udport          The UDP destination port to match on.\n");
+
+        printf("  --icmp            Enable or disables matching on the ICMP protocol.\n");
+        printf("  --code            The ICMP code to match on.\n");
+        printf("  --type            The ICMP type to match on.\n");
+
+        return EXIT_SUCCESS;
+    }
+
+    // Check for config file path.
+    if ((cmd.save || cmd.mode == 0) && (!cmd.cfg_file || strlen(cmd.cfg_file) < 1))
+    {
+        fprintf(stderr, "[ERROR] CFG file not specified or empty. This is required for filters mode or when saving config.\n");
+
+        return EXIT_FAILURE;
+    }
+
+    // Load config.
+    config__t cfg = {0};
+    
+    if (cmd.save || cmd.mode == 0)
+    {
+        if ((ret = LoadConfig(&cfg, cmd.cfg_file, NULL)) != 0)
+        {
+            fprintf(stderr, "[ERROR] Failed to load config at '%s' (%d)\n", cmd.cfg_file, ret);
+
+            return EXIT_FAILURE;
+        }
+
+        printf("Loaded config...\n");
+    }
+
+    // Handle filters mode.
+    if (cmd.mode == 0)
+    {
+        printf("Using filters mode (0)...\n");
+
+        // Check index.
+        if (cmd.idx < 1)
+        {
+            fprintf(stderr, "Invalid filter index. Index must start from 1.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        // Retrieve filters map FD.
+        int map_filters = GetMapPinFd(XDP_MAP_PIN_DIR, "map_filters");
+
+        if (map_filters < 0)
+        {
+            fprintf(stderr, "[ERROR] Failed to retrieve BPF map 'map_filters' from file system.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        printf("Using 'map_filters' FD => %d...\n", map_filters);
+
+        // Create new base filter and set its defaults.
+        filter_t new_filter = {0};
+        SetFilterDefaults(&new_filter);
+
+        // Determine what index we'll be storing this filter at.
+        int idx = -1;
+
+        if (cmd.idx > 0)
+        {
+            idx = cmd.idx - 1;
+        }
+        else
+        {
+            idx = GetNextAvailableFilterIndex(&cfg);
+        }
+
+        if (idx < 0)
+        {
+            fprintf(stderr, "Failed to retrieve filter next. Make sure you haven't exceeded the maximum filters allowed (%d).\n", MAX_FILTERS);
+
+            return EXIT_FAILURE;
+        }
+
+        // Fill out new filter.
+        if (cmd.src_ip)
+        {
+            ip_range_t range = ParseIpCidr(cmd.src_ip);
+
+            new_filter.src_ip = range.ip;
+            new_filter.src_cidr = range.cidr;
+        }
+
+        if (cmd.dst_ip)
+        {
+            ip_range_t range = ParseIpCidr(cmd.dst_ip);
+
+            new_filter.dst_ip = range.ip;
+            new_filter.dst_cidr = range.cidr;
+        }
+
+        if (cmd.src_ip6)
+        {
+            struct in6_addr addr;
+
+            if ((ret = inet_pton(AF_INET6, cmd.src_ip6, &addr)) != 1)
+            {
+                fprintf(stderr, "Failed to convert source IPv6 address to decimal (%d).\n", ret);
+
+                return EXIT_FAILURE;
+            }
+
+            memcpy(new_filter.src_ip6, addr.s6_addr, sizeof(new_filter.src_ip6));
+        }
+
+        if (cmd.dst_ip6)
+        {
+            struct in6_addr addr;
+
+            if ((ret = inet_pton(AF_INET6, cmd.dst_ip6, &addr)) != 1)
+            {
+                fprintf(stderr, "Failed to convert destination IPv6 address to decimal (%d).\n", ret);
+
+                return EXIT_FAILURE;
+            }
+
+            memcpy(new_filter.dst_ip6, addr.s6_addr, sizeof(new_filter.dst_ip6));
+        }
+
+        // To Do: See if I can create a macro for below.
+        // As long as the naming convention lines up, it should be easily possible.
+        if (cmd.pps > -1)
+        {
+            new_filter.do_pps = 1;
+            new_filter.pps = cmd.pps;
+        }
+
+        if (cmd.bps > -1)
+        {
+            new_filter.do_bps = 1;
+            new_filter.bps = cmd.bps;
+        }
+
+        if (cmd.min_ttl > -1)
+        {
+            new_filter.do_min_ttl = 1;
+            new_filter.min_ttl = cmd.min_ttl;
+        }
+
+        if (cmd.max_ttl > -1)
+        {
+            new_filter.do_max_ttl = 1;
+            new_filter.max_ttl = cmd.max_ttl;
+        }
+
+        if (cmd.min_len > -1)
+        {
+            new_filter.do_min_len = 1;
+            new_filter.min_len = cmd.min_len;
+        }
+
+        if (cmd.max_len > -1)
+        {
+            new_filter.do_max_len = 1;
+            new_filter.max_len = cmd.max_len;
+        }
+
+        if (cmd.tos > -1)
+        {
+            new_filter.do_tos = 1;
+            new_filter.tos = cmd.tos;
+        }
+
+        if (cmd.tcp_enabled > -1)
+        {
+            new_filter.tcpopts.enabled = cmd.tcp_enabled;
+        }
+
+        if (cmd.tcp_sport > -1)
+        {
+            new_filter.tcpopts.do_sport = 1;
+            new_filter.tcpopts.sport = cmd.tcp_sport;
+        }
+
+        if (cmd.tcp_dport > -1)
+        {
+            new_filter.tcpopts.do_dport = 1;
+            new_filter.tcpopts.dport = cmd.tcp_dport;
+        }
+
+        if (cmd.tcp_urg > -1)
+        {
+            new_filter.tcpopts.do_urg = 1;
+            new_filter.tcpopts.urg = cmd.tcp_urg;
+        }
+
+        if (cmd.tcp_ack > -1)
+        {
+            new_filter.tcpopts.do_ack = 1;
+            new_filter.tcpopts.ack = cmd.tcp_ack;
+        }
+
+        if (cmd.tcp_rst > -1)
+        {
+            new_filter.tcpopts.do_rst = 1;
+            new_filter.tcpopts.rst = cmd.tcp_rst;
+        }
+
+        if (cmd.tcp_psh > -1)
+        {
+            new_filter.tcpopts.do_psh = 1;
+            new_filter.tcpopts.psh = cmd.tcp_psh;
+        }
+
+        if (cmd.tcp_syn > -1)
+        {
+            new_filter.tcpopts.do_syn = 1;
+            new_filter.tcpopts.syn = cmd.tcp_syn;
+        }
+
+        if (cmd.tcp_fin > -1)
+        {
+            new_filter.tcpopts.do_fin = 1;
+            new_filter.tcpopts.fin = cmd.tcp_fin;
+        }
+
+        if (cmd.tcp_ece > -1)
+        {
+            new_filter.tcpopts.do_ece = 1;
+            new_filter.tcpopts.ece = cmd.tcp_ece;
+        }
+
+        if (cmd.tcp_cwr > -1)
+        {
+            new_filter.tcpopts.do_cwr = 1;
+            new_filter.tcpopts.cwr = cmd.tcp_cwr;
+        }
+
+        if (cmd.udp_enabled > -1)
+        {
+            new_filter.udpopts.enabled = cmd.udp_enabled;
+        }
+
+        if (cmd.udp_sport > -1)
+        {
+            new_filter.udpopts.do_sport = 1;
+            new_filter.udpopts.sport = cmd.udp_sport;
+        }
+
+        if (cmd.udp_dport > -1)
+        {
+            new_filter.udpopts.do_dport = 1;
+            new_filter.udpopts.dport = cmd.udp_dport;
+        }
+
+        if (cmd.icmp_enabled > -1)
+        {
+            new_filter.icmpopts.enabled = cmd.icmp_enabled;
+        }
+
+        if (cmd.icmp_code > -1)
+        {
+            new_filter.icmpopts.do_code = 1;
+            new_filter.icmpopts.code = cmd.icmp_code;
+        }
+
+        if (cmd.icmp_type > -1)
+        {
+            new_filter.icmpopts.do_type = 1;
+            new_filter.icmpopts.type = cmd.icmp_type;
+        }
+
+        // Set filter at index.
+        cfg.filters[idx] = new_filter;
+
+        // Update filters.
+        fprintf(stdout, "Updating filters...\n");
+
+        UpdateFilters(map_filters, &cfg);
+    }
+    // Handle IPv4 range drop mode.
+    else if (cmd.mode == 1)
+    {
+        printf("Using IPv4 range drop mode (1)...\n");
+
+        // Make sure IP range is specified.
+        if (!cmd.ip)
+        {
+            fprintf(stderr, "No IP address or range specified. Please set an IP range using -d, --ip arguments.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        // Get range map.
+        int map_range_drop = GetMapPinFd(XDP_MAP_PIN_DIR, "map_range_drop");
+
+        if (map_range_drop < 0)
+        {
+            fprintf(stderr, "Failed to retrieve 'map_range_drop' BPF map FD.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        printf("Using 'map_range_drop' FD => %d.\n", map_range_drop);
+
+        // Parse IP range.
+        ip_range_t range = ParseIpCidr(cmd.ip);
+
+        // Attempt to add range.
+        if ((ret = AddRangeDrop(map_range_drop, range.ip, range.cidr)) != 0)
+        {
+            fprintf(stderr, "Error adding range to BPF map (%d).\n", ret);
+
+            return EXIT_FAILURE;
+        }
+
+        printf("Added IP range '%s' to IP range drop map...\n", cmd.ip);
+
+        if (cmd.save)
+        {
+            // Get next available index.
+            int idx = GetNextAvailableIpDropRangeIndex(&cfg);
+
+            if (idx < 0)
+            {
+                fprintf(stderr, "No available IP drop range indexes. Perhaps the maximum IP ranges has been exceeded?\n");
+
+                return EXIT_FAILURE;
+            }
+
+            cfg.drop_ranges[idx] = strdup(cmd.ip);
+        }
+    }
+    // Handle block map mode.
+    else
+    {
+        printf("Using source IP block mode (2)...\n");
+
+        if (!cmd.ip)
+        {
+            fprintf(stderr, "No source IP address specified. Please set an IP using -s, --ip arguments.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        int expires = 0;
+
+        if (cmd.expires > -1)
+        {
+            expires = cmd.expires;
+        }
+
+        u64 expires_rel = GetBootNanoTime() + ((u64)expires * 1e9);
+
+        int map_block = GetMapPinFd(XDP_MAP_PIN_DIR, "map_block");
+        int map_block6 = GetMapPinFd(XDP_MAP_PIN_DIR, "map_block6");
+
+        if (cmd.v6)
+        {
+            if (map_block6 < 0)
+            {
+                fprintf(stderr, "Failed to find the 'map_block6' BPF map.\n");
+
+                return EXIT_FAILURE;
+            }
+
+            printf("Using 'map_block6' FD => %d.\n", map_block6);
+
+            struct in6_addr addr;
+
+            if ((ret = inet_pton(AF_INET6, cmd.ip, &addr)) != 1)
+            {
+                fprintf(stderr, "Failed to convert IPv6 address '%s' to decimal (%d).\n", cmd.ip, ret);
+
+                return EXIT_FAILURE;
+            }
+
+            u128 ip = 0;
+
+            for (int i = 0; i < 16; i++)
+            {
+                ip = (ip << 8) | addr.s6_addr[i];
+            }
+
+            if ((ret = AddBlock6(map_block6, ip, expires_rel)) != 0)
+            {
+                fprintf(stderr, "Failed to add IP '%s' to BPF map (%d).\n", cmd.ip, ret);
+
+                return EXIT_FAILURE;
+            }
+        }
+        else
+        {
+            if (map_block < 0)
+            {
+                fprintf(stderr, "Failed to find the 'map_block' BPF map.\n");
+
+                return EXIT_FAILURE;
+            }
+
+            printf("Using 'map_block' FD => %d.\n", map_block);
+
+            struct in_addr addr;
+
+            if ((ret = inet_pton(AF_INET, cmd.ip, &addr)) != 1)
+            {
+                fprintf(stderr, "Failed to convert IP address '%s' to decimal (%d).\n", cmd.ip, ret);
+
+                return EXIT_FAILURE;
+            }
+
+            if ((ret = AddBlock(map_block, addr.s_addr, expires_rel)) != 0)
+            {
+                fprintf(stderr, "Failed to add IP '%s' too BPF map (%d).\n", cmd.ip, ret);
+
+                return EXIT_FAILURE;
+            }
+
+            printf("Added '%s' to block map...\n", cmd.ip);
+        }
+    }
+
+    if (cmd.save)
+    {
+        // Save config.
+        printf("Saving config...\n");
+
+        if ((ret = SaveCfg(&cfg, cmd.cfg_file)) != 0)
+        {
+            fprintf(stderr, "[ERROR] Failed to save config.\n");
+
+            return EXIT_FAILURE;
+        }
+    }
+
+    printf("Success! Exiting.\n");
+
+    return EXIT_SUCCESS;
+}

--- a/src/rule_add/prog.c
+++ b/src/rule_add/prog.c
@@ -22,6 +22,36 @@ int main(int argc, char *argv[])
     cmdline_t cmd = {0};
     cmd.cfg_file = CONFIG_DEFAULT_PATH;
 
+    // We need to set integers for dynamic filters to -1 since we consider -1 as 'unset'.
+    cmd.min_ttl = -1;
+    cmd.max_ttl = -1;
+    cmd.min_len = -1;
+    cmd.max_len = -1;
+    cmd.tos = -1;
+
+    cmd.pps = -1;
+    cmd.bps = -1;
+
+    cmd.tcp_enabled = -1;
+    cmd.tcp_sport = -1;
+    cmd.tcp_dport = -1;
+    cmd.tcp_urg = -1;
+    cmd.tcp_ack = -1;
+    cmd.tcp_rst = -1;
+    cmd.tcp_psh = -1;
+    cmd.tcp_syn = -1;
+    cmd.tcp_fin = -1;
+    cmd.tcp_ece = -1;
+    cmd.tcp_cwr = -1;
+
+    cmd.udp_enabled = -1;
+    cmd.udp_sport = -1;
+    cmd.udp_dport = -1;
+    
+    cmd.icmp_enabled = -1;
+    cmd.icmp_code = -1;
+    cmd.icmp_type = -1;
+
     ParseCommandLine(&cmd, argc, argv);
 
     if (!cmd.help)

--- a/src/rule_add/prog.c
+++ b/src/rule_add/prog.c
@@ -463,14 +463,12 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
 
-        int expires = 0;
+        u64 expires_rel = 0;
 
-        if (cmd.expires > -1)
+        if (cmd.expires > 0)
         {
-            expires = cmd.expires;
+            expires_rel = GetBootNanoTime() + ((u64)cmd.expires * 1e9);
         }
-
-        u64 expires_rel = GetBootNanoTime() + ((u64)expires * 1e9);
 
         int map_block = GetMapPinFd(XDP_MAP_PIN_DIR, "map_block");
         int map_block6 = GetMapPinFd(XDP_MAP_PIN_DIR, "map_block6");
@@ -536,7 +534,14 @@ int main(int argc, char *argv[])
                 return EXIT_FAILURE;
             }
 
-            printf("Added '%s' to block map...\n", cmd.ip);
+            if (cmd.expires > 0)
+            {
+                printf("Added '%s' to block map for %lld seconds...\n", cmd.ip, cmd.expires);
+            }
+            else
+            {
+                printf("Added '%s' to block map indefinitely...\n", cmd.ip);
+            }
         }
     }
 

--- a/src/rule_add/utils/cmdline.c
+++ b/src/rule_add/utils/cmdline.c
@@ -15,6 +15,11 @@ const struct option opts[] =
     { "v6", no_argument, NULL, 'v' },
     { "expires", required_argument, NULL, 'e' },
 
+    { "enabled", required_argument, NULL, 28 },
+    { "action", required_argument, NULL, 29 },
+    { "log", required_argument, NULL, 30 },
+    { "block-time", required_argument, NULL, 31 },
+
     { "sip", required_argument, NULL, 0 },
     { "dip", required_argument, NULL, 1 },
     { "sip6", required_argument, NULL, 2 },
@@ -96,6 +101,26 @@ void ParseCommandLine(cmdline_t* cmd, int argc, char* argv[])
 
             case 'e':
                 cmd->expires = strtoll(optarg, NULL, 10);
+
+                break;
+
+            case 28:
+                cmd->enabled = atoi(optarg);
+
+                break;
+
+            case 29:
+                cmd->action = atoi(optarg);
+
+                break;
+
+            case 30:
+                cmd->log = atoi(optarg);
+
+                break;
+
+            case 31:
+                cmd->block_time = strtoll(optarg, NULL, 10);
 
                 break;
 

--- a/src/rule_add/utils/cmdline.c
+++ b/src/rule_add/utils/cmdline.c
@@ -1,0 +1,251 @@
+#include <rule_add/utils/cmdline.h>
+
+const struct option opts[] =
+{
+    { "cfg", required_argument, NULL, 'c' },
+    { "help", no_argument, NULL, 'h' },
+
+    { "save", no_argument, NULL, 's' },
+
+    { "mode", required_argument, NULL, 'm' },
+    
+    { "idx", required_argument, NULL, 'i' },
+
+    { "ip", required_argument, NULL, 'd' },
+    { "v6", no_argument, NULL, 'v' },
+    { "expires", required_argument, NULL, 'e' },
+
+    { "sip", required_argument, NULL, 0 },
+    { "dip", required_argument, NULL, 1 },
+    { "sip6", required_argument, NULL, 2 },
+    { "dip6", required_argument, NULL, 3 },
+    { "min-ttl", required_argument, NULL, 4 },
+    { "max-ttl", required_argument, NULL, 5 },
+    { "min-len", required_argument, NULL, 6 },
+    { "max-len", required_argument, NULL, 7 },
+    { "tos", required_argument, NULL, 8 },
+
+    { "pps", required_argument, NULL, 9 },
+    { "bps", required_argument, NULL, 10 },
+
+    { "tcp", required_argument, NULL, 11 },
+    { "tsport", required_argument, NULL, 12 },
+    { "tdport", required_argument, NULL, 13 },
+    { "urg", required_argument, NULL, 14 },
+    { "ack", required_argument, NULL, 15 },
+    { "rst", required_argument, NULL, 16 },
+    { "psh", required_argument, NULL, 17 },
+    { "syn", required_argument, NULL, 18 },
+    { "fin", required_argument, NULL, 19 },
+    { "ece", required_argument, NULL, 20 },
+    { "cwr", required_argument, NULL, 21 },
+
+    { "udp", required_argument, NULL, 22 },
+    { "usport", required_argument, NULL, 23 },
+    { "udport", required_argument, NULL, 24 },
+    
+    { "icmp", required_argument, NULL, 25 },
+    { "code", required_argument, NULL, 26 },
+    { "type", required_argument, NULL, 27 },
+
+    { NULL, 0, NULL, 0 }
+};
+
+void ParseCommandLine(cmdline_t* cmd, int argc, char* argv[])
+{
+    int c;
+
+    while ((c = getopt_long(argc, argv, "c:lhm:i:rsv", opts, NULL)) != -1)
+    {
+        switch (c)
+        {
+            case 'c':
+                cmd->cfg_file = optarg;
+
+                break;
+
+            case 'h':
+                cmd->help = 1;
+
+                break;
+
+            case 's':
+                cmd->save = 1;
+
+                break;
+
+            case 'm':
+                cmd->mode = atoi(optarg);
+
+                break;
+
+            case 'i':
+                cmd->idx = atoi(optarg);
+
+                break;
+
+            case 'd':
+                cmd->ip = optarg;
+
+                break;
+
+            case 'v':
+                cmd->v6 = atoi(optarg);
+
+                break;
+
+            case 'e':
+                cmd->expires = strtoll(optarg, NULL, 10);
+
+                break;
+
+            case 0:
+                cmd->src_ip = optarg;
+
+                break;
+
+            case 1:
+                cmd->dst_ip = optarg;
+
+                break;
+
+            case 2:
+                cmd->src_ip6 = optarg;
+                
+                break;
+
+            case 3:
+                cmd->dst_ip6 = optarg;
+
+                break;
+
+            case 4:
+                cmd->min_ttl = atoi(optarg);
+
+                break;
+
+            case 5:
+                cmd->max_ttl = atoi(optarg);
+
+                break;
+
+            case 6:
+                cmd->min_len = atoi(optarg);
+
+                break;
+
+            case 7:
+                cmd->max_len = atoi(optarg);
+
+                break;
+
+            case 8:
+                cmd->tos = atoi(optarg);
+
+                break;
+
+            case 9:
+                cmd->pps = strtoll(optarg, NULL, 10);
+
+                break;
+
+            case 10:
+                cmd->bps = strtoll(optarg, NULL, 10);
+
+                break;
+
+            case 11:
+                cmd->tcp_enabled = atoi(optarg);
+
+                break;
+
+            case 12:
+                cmd->tcp_sport = atoi(optarg);
+
+                break;
+
+            case 13:
+                cmd->tcp_dport = atoi(optarg);
+
+                break;
+
+            case 14:
+                cmd->tcp_urg = atoi(optarg);
+
+                break;
+
+            case 15:
+                cmd->tcp_ack = atoi(optarg);
+
+                break;
+
+            case 16:
+                cmd->tcp_rst = atoi(optarg);
+
+                break;
+
+            case 17:
+                cmd->tcp_psh = atoi(optarg);
+
+                break;
+
+            case 18:
+                cmd->tcp_syn = atoi(optarg);
+
+                break;
+
+            case 19:
+                cmd->tcp_fin = atoi(optarg);
+
+                break;
+
+            case 20:
+                cmd->tcp_ece = atoi(optarg);
+
+                break;
+
+            case 21:
+                cmd->tcp_cwr = atoi(optarg);
+
+                break;
+
+            case 22:
+                cmd->udp_enabled = atoi(optarg);
+
+                break;
+
+            case 23:
+                cmd->udp_sport = atoi(optarg);
+
+                break;
+
+            case 24:
+                cmd->udp_dport = atoi(optarg);
+
+                break;
+
+            case 25:
+                cmd->icmp_enabled = atoi(optarg);
+
+                break;
+
+            case 26:
+                cmd->icmp_code = atoi(optarg);
+
+                break;
+
+            case 27:
+                cmd->icmp_type = atoi(optarg);
+
+                break;
+            
+            case '?':
+                fprintf(stderr, "Missing argument option...\n");
+
+                break;
+
+            default:
+                break;
+        }
+    }
+}

--- a/src/rule_add/utils/cmdline.h
+++ b/src/rule_add/utils/cmdline.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <common/all.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+struct cmdline
+{
+    const char* cfg_file;
+
+    int help;
+
+    int save;
+
+    int mode;
+
+    int idx;
+
+    const char* ip;
+    int v6;
+
+    s64 expires;
+
+    const char* src_ip;
+    const char* dst_ip;
+
+    const char* src_ip6;
+    const char* dst_ip6;
+
+    s64 pps;
+    s64 bps;
+
+    int min_ttl;
+    int max_ttl;
+    int min_len;
+    int max_len;
+    int tos;
+
+    int tcp_enabled;
+    int tcp_sport;
+    int tcp_dport;
+    int tcp_urg;
+    int tcp_ack;
+    int tcp_rst;
+    int tcp_psh;
+    int tcp_syn;
+    int tcp_fin;
+    int tcp_ece;
+    int tcp_cwr;
+
+    int udp_enabled;
+    int udp_sport;
+    int udp_dport;
+
+    int icmp_enabled;
+    int icmp_code;
+    int icmp_type;
+} typedef cmdline_t;
+
+void ParseCommandLine(cmdline_t* cmd, int argc, char* argv[]);

--- a/src/rule_add/utils/cmdline.h
+++ b/src/rule_add/utils/cmdline.h
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <getopt.h>
 
+#include <string.h>
+
 struct cmdline
 {
     const char* cfg_file;
@@ -22,6 +24,11 @@ struct cmdline
     int v6;
 
     s64 expires;
+
+    int enabled;
+    int log;
+    int action;
+    s64 block_time;
 
     const char* src_ip;
     const char* dst_ip;

--- a/src/rule_del/prog.c
+++ b/src/rule_del/prog.c
@@ -1,0 +1,287 @@
+#include <common/all.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <loader/utils/xdp.h>
+#include <loader/utils/config.h>
+
+#include <rule_del/utils/cmdline.h>
+
+// These are required due to being extern with Loader.
+// To Do: Figure out a way to not require the below without requiring separate object files.
+int cont = 0;
+int doing_stats = 0;
+
+int main(int argc, char *argv[])
+{
+    int ret;
+
+    // Parse command line.
+    cmdline_t cmd = {0};
+    cmd.cfg_file = CONFIG_DEFAULT_PATH;
+
+    ParseCommandLine(&cmd, argc, argv);
+
+    if (!cmd.help)
+    {
+        printf("Parsed command line...\n");
+    } else
+    {
+        printf("Usage: xdpfw-del [OPTIONS]\n\n");
+        printf("OPTIONS:\n");
+        printf("  -c, --cfg         The path to the config file (default /etc/xdpfw/xdpfw.conf).\n");
+        printf("  -s, --save        Saves the new config to file system.\n");
+        printf("  -m, --mode        The mode to use (0 = filters, 1 = IPv4 range drop, 2 = IP block map).\n");
+        printf("  -i, --idx         The filters index to remove when using filters mode (0) (index starts from 1; retrieve index using xdpfw -l).\n");
+        printf("  -d, --ip          The IP range or single IP to use (for modes 1 and 2).\n");
+        printf("  -v, --v6          If set, parses IP address as IPv6 when removing from block map (for mode 2).\n");
+
+        return EXIT_SUCCESS;
+    }
+
+    // Check for config file path.
+    if ((cmd.save || cmd.mode == 0) && (!cmd.cfg_file || strlen(cmd.cfg_file) < 1))
+    {
+        fprintf(stderr, "[ERROR] CFG file not specified or empty. This is required for current mode or options set.\n");
+
+        return EXIT_FAILURE;
+    }
+
+    // Load config.
+    config__t cfg = {0};
+    
+    if (cmd.save || cmd.mode == 0)
+    {
+        if ((ret = LoadConfig(&cfg, cmd.cfg_file, NULL)) != 0)
+        {
+            fprintf(stderr, "[ERROR] Failed to load config at '%s' (%d)\n", cmd.cfg_file, ret);
+
+            return EXIT_FAILURE;
+        }
+
+        printf("Loaded config...\n");
+    }
+
+    // Handle filters mode.
+    if (cmd.mode == 0)
+    {
+        printf("Using filters mode (0)...\n");
+
+        // Check index.
+        if (cmd.idx < 1)
+        {
+            fprintf(stderr, "Invalid filter index. Index must start from 1.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        // Retrieve filters map FD.
+        int map_filters = GetMapPinFd(XDP_MAP_PIN_DIR, "map_filters");
+
+        if (map_filters < 0)
+        {
+            fprintf(stderr, "[ERROR] Failed to retrieve BPF map 'map_filters' from file system.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        printf("Using 'map_filters' FD => %d...\n", map_filters);
+
+        int index = -1;
+        int cfg_idx = cmd.idx - 1;
+        int cur_idx = 0;
+
+        // This is where things are a bit tricky due to the layout of our filtering system in XDP.
+        // Since each filter rule doesn't have any unique identifier other than the index, we need to use that.
+        // However, rules that are not enabled are not inserted into the BPF map which can mismatch the indexes in the config and XDP program.
+        // So we need to loop through each and ignore disabled rules.
+        for (int i = 0; i < MAX_FILTERS; i++)
+        {
+            filter_t* filter = &cfg.filters[i];
+
+            if (!filter->set || !filter->enabled)
+            {
+                continue;
+            }
+
+            if (i == cur_idx)
+            {
+                index = cur_idx;
+
+                break;
+            }
+
+            cur_idx++;
+        }
+
+        if (index < 0)
+        {
+            fprintf(stderr, "[ERROR] Failed to find proper index in config file (%d).\n", index);
+
+            return EXIT_FAILURE;
+        }
+
+        // Unset affected filter in config.
+        if (cmd.save)
+        {
+            cfg.filters[cfg_idx].set = 0;
+        }
+
+        // Update filters.
+        fprintf(stdout, "Updating filters...\n");
+
+        UpdateFilters(map_filters, &cfg);
+    }
+    // Handle IPv4 range drop mode.
+    else if (cmd.mode == 1)
+    {
+        printf("Using IPv4 range drop mode (1)...\n");
+
+        // Make sure IP range is specified.
+        if (!cmd.ip)
+        {
+            fprintf(stderr, "No IP address or range specified. Please set an IP range using -s, --ip arguments.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        // Get range map.
+        int map_range_drop = GetMapPinFd(XDP_MAP_PIN_DIR, "map_range_drop");
+
+        if (map_range_drop < 0)
+        {
+            fprintf(stderr, "Failed to retrieve 'map_range_drop' BPF map FD.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        // Parse IP range.
+        ip_range_t range = ParseIpCidr(cmd.ip);
+
+        // Attempt to delete range.
+        if ((ret = DeleteRangeDrop(map_range_drop, range.ip, range.cidr)) != 0)
+        {
+            fprintf(stderr, "Error deleting range from BPF map (%d).\n", ret);
+
+            return EXIT_FAILURE;
+        }
+
+        printf("Removed IP range '%s' from BPF map.\n", cmd.ip);
+
+        if (cmd.save)
+        {
+            // Loop through IP drop ranges and unset if found.
+            for (int i = 0; i < MAX_IP_RANGES; i++)
+            {
+                const char* cur_range = cfg.drop_ranges[i];
+
+                if (!cur_range)
+                {
+                    continue;
+                }
+
+                if (strcmp(cur_range, cmd.ip) != 0)
+                {
+                    continue;
+                }
+
+                free((void*)cfg.drop_ranges[i]);
+                cfg.drop_ranges[i] = NULL;
+            }
+        }
+    }
+    // Handle block map mode.
+    else
+    {
+        printf("Using source IP block mode (2)...\n");
+
+        if (!cmd.ip)
+        {
+            fprintf(stderr, "No source IP address specified. Please set an IP using -s, --ip arguments.\n");
+
+            return EXIT_FAILURE;
+        }
+
+        int map_block = GetMapPinFd(XDP_MAP_PIN_DIR, "map_block");
+        int map_block6 = GetMapPinFd(XDP_MAP_PIN_DIR, "map_block6");
+
+        if (cmd.v6)
+        {
+            if (map_block6 < 0)
+            {
+                fprintf(stderr, "Failed to find the 'map_block6' BPF map.\n");
+
+                return EXIT_FAILURE;
+            }
+
+            struct in6_addr addr;
+
+            if ((ret = inet_pton(AF_INET6, cmd.ip, &addr)) != 1)
+            {
+                fprintf(stderr, "Failed to convert IPv6 address '%s' to decimal (%d).\n", cmd.ip, ret);
+
+                return EXIT_FAILURE;
+            }
+
+            u128 ip = 0;
+
+            for (int i = 0; i < 16; i++)
+            {
+                ip = (ip << 8) | addr.s6_addr[i];
+            }
+
+            if ((ret = DeleteBlock6(map_block6, ip)) != 0)
+            {
+                fprintf(stderr, "Failed to delete IP '%s' from BPF map (%d).\n", cmd.ip, ret);
+
+                return EXIT_FAILURE;
+            }
+        }
+        else
+        {
+            if (map_block < 0)
+            {
+                fprintf(stderr, "Failed to find the 'map_block' BPF map.\n");
+
+                return EXIT_FAILURE;
+            }
+
+            struct in_addr addr;
+
+            if ((ret = inet_pton(AF_INET, cmd.ip, &addr)) != 1)
+            {
+                fprintf(stderr, "Failed to convert IP address '%s' to decimal (%d).\n", cmd.ip, ret);
+
+                return EXIT_FAILURE;
+            }
+
+            if ((ret = DeleteBlock(map_block, addr.s_addr)) != 0)
+            {
+                fprintf(stderr, "Failed to delete IP '%s' from BPF map (%d).\n", cmd.ip, ret);
+
+                return EXIT_FAILURE;
+            }
+
+            printf("Deleted '%s' from block map...\n", cmd.ip);
+        }
+    }
+
+    if (cmd.save)
+    {
+        // Save config.
+        printf("Saving config...\n");
+
+        if ((ret = SaveCfg(&cfg, cmd.cfg_file)) != 0)
+        {
+            fprintf(stderr, "[ERROR] Failed to save config.\n");
+
+            return EXIT_FAILURE;
+        }
+    }
+
+    printf("Success! Exiting.\n");
+
+    return EXIT_SUCCESS;
+}

--- a/src/rule_del/prog.c
+++ b/src/rule_del/prog.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
 
         printf("Using 'map_filters' FD => %d...\n", map_filters);
 
-        int index = -1;
+        int idx = -1;
         int cfg_idx = cmd.idx - 1;
         int cur_idx = 0;
 
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 
             if (i == cur_idx)
             {
-                index = cur_idx;
+                idx = cur_idx;
 
                 break;
             }
@@ -116,9 +116,9 @@ int main(int argc, char *argv[])
             cur_idx++;
         }
 
-        if (index < 0)
+        if (idx < 0)
         {
-            fprintf(stderr, "[ERROR] Failed to find proper index in config file (%d).\n", index);
+            fprintf(stderr, "[ERROR] Failed to find proper index in config file (%d).\n", idx);
 
             return EXIT_FAILURE;
         }

--- a/src/rule_del/prog.c
+++ b/src/rule_del/prog.c
@@ -157,6 +157,8 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
 
+        printf("Using 'map_range_drop' FD => %d.\n", map_range_drop);
+
         // Parse IP range.
         ip_range_t range = ParseIpCidr(cmd.ip);
 
@@ -168,7 +170,7 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
 
-        printf("Removed IP range '%s' from BPF map.\n", cmd.ip);
+        printf("Removed IP range '%s'...\n", cmd.ip);
 
         if (cmd.save)
         {
@@ -216,6 +218,8 @@ int main(int argc, char *argv[])
                 return EXIT_FAILURE;
             }
 
+            printf("Using 'map_block6' FD => %d.\n", map_block6);
+
             struct in6_addr addr;
 
             if ((ret = inet_pton(AF_INET6, cmd.ip, &addr)) != 1)
@@ -248,6 +252,8 @@ int main(int argc, char *argv[])
                 return EXIT_FAILURE;
             }
 
+            printf("Using 'map_block' FD => %d.\n", map_block);
+
             struct in_addr addr;
 
             if ((ret = inet_pton(AF_INET, cmd.ip, &addr)) != 1)
@@ -264,7 +270,7 @@ int main(int argc, char *argv[])
                 return EXIT_FAILURE;
             }
 
-            printf("Deleted '%s' from block map...\n", cmd.ip);
+            printf("Deleted IP '%s'...\n", cmd.ip);
         }
     }
 

--- a/src/rule_del/utils/cmdline.c
+++ b/src/rule_del/utils/cmdline.c
@@ -1,0 +1,71 @@
+#include <rule_del/utils/cmdline.h>
+
+const struct option opts[] =
+{
+    { "cfg", required_argument, NULL, 'c' },
+    { "help", no_argument, NULL, 'h' },
+
+    { "save", no_argument, NULL, 's' },
+
+    { "mode", required_argument, NULL, 'm' },
+    
+    { "idx", required_argument, NULL, 'i' },
+    { "ip", required_argument, NULL, 'd' },
+    { "v6", no_argument, NULL, 'v' },
+
+    { NULL, 0, NULL, 0 }
+};
+
+void ParseCommandLine(cmdline_t* cmd, int argc, char* argv[])
+{
+    int c;
+
+    while ((c = getopt_long(argc, argv, "c:lhm:i:rsv", opts, NULL)) != -1)
+    {
+        switch (c)
+        {
+            case 'c':
+                cmd->cfg_file = optarg;
+
+                break;
+
+            case 'h':
+                cmd->help = 1;
+
+                break;
+
+            case 's':
+                cmd->save = 1;
+
+                break;
+
+            case 'm':
+                cmd->mode = atoi(optarg);
+
+                break;
+
+            case 'i':
+                cmd->idx = atoi(optarg);
+
+                break;
+
+            case 'd':
+                cmd->ip = optarg;
+
+                break;
+
+            case 'v':
+                cmd->v6 = 1;
+
+                break;
+            
+            case '?':
+                fprintf(stderr, "Missing argument option...\n");
+
+                break;
+
+            default:
+                break;
+        }
+    }
+}

--- a/src/rule_del/utils/cmdline.h
+++ b/src/rule_del/utils/cmdline.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+struct cmdline
+{
+    const char* cfg_file;
+
+    int help;
+
+    int save;
+
+    int mode;
+
+    int idx;
+
+    const char* ip;
+    int v6;
+} typedef cmdline_t;
+
+void ParseCommandLine(cmdline_t* cmd, int argc, char* argv[]);

--- a/src/xdp/prog.c
+++ b/src/xdp/prog.c
@@ -96,9 +96,9 @@ int xdp_prog_main(struct xdp_md *ctx)
         blocked = bpf_map_lookup_elem(&map_block, &iph->saddr);
     }
     
-    if (blocked != NULL && *blocked > 0)
+    if (blocked != NULL)
     {
-        if (now > *blocked)
+        if (*blocked > 0 && now > *blocked)
         {
             // Remove element from map.
             if (iph6)

--- a/src/xdp/prog.c
+++ b/src/xdp/prog.c
@@ -44,9 +44,6 @@ int xdp_prog_main(struct xdp_md *ctx)
         return XDP_PASS;
     }
 
-    u8 action = 0;
-    u64 block_time = 1;
-
     // Initialize IP headers.
     struct iphdr *iph = NULL;
     struct ipv6hdr *iph6 = NULL;
@@ -62,7 +59,7 @@ int xdp_prog_main(struct xdp_md *ctx)
             return XDP_DROP;
         }
 
-        memcpy(&src_ip6, &iph6->saddr.in6_u.u6_addr32, sizeof(src_ip6));
+        memcpy(&src_ip6, iph6->saddr.in6_u.u6_addr32, sizeof(src_ip6));
     }
     else
     {
@@ -74,28 +71,29 @@ int xdp_prog_main(struct xdp_md *ctx)
         }
     }
     
-    // Check IP header protocols.
+    // We only want to process TCP, UDP, and ICMP packets.
     if ((iph6 && iph6->nexthdr != IPPROTO_UDP && iph6->nexthdr != IPPROTO_TCP && iph6->nexthdr != IPPROTO_ICMP) && (iph && iph->protocol != IPPROTO_UDP && iph->protocol != IPPROTO_TCP && iph->protocol != IPPROTO_ICMP))
     {
         return XDP_PASS;
     }
 
-    // Get stats map.
+    // Retrieve stats map value.
     u32 key = 0;
     stats_t*stats = bpf_map_lookup_elem(&map_stats, &key);
 
+    // Retrieve nanoseconds since system boot as timestamp.
     u64 now = bpf_ktime_get_ns();
 
-    // Check blacklist map.
+    // Check block map.
     u64 *blocked = NULL;
 
     if (iph6)
     {
-        blocked = bpf_map_lookup_elem(&map_ip6_blacklist, &src_ip6);
+        blocked = bpf_map_lookup_elem(&map_block6, &src_ip6);
     }
     else if (iph)
     {
-        blocked = bpf_map_lookup_elem(&map_ip_blacklist, &iph->saddr);
+        blocked = bpf_map_lookup_elem(&map_block, &iph->saddr);
     }
     
     if (blocked != NULL && *blocked > 0)
@@ -105,11 +103,11 @@ int xdp_prog_main(struct xdp_md *ctx)
             // Remove element from map.
             if (iph6)
             {
-                bpf_map_delete_elem(&map_ip6_blacklist, &src_ip6);
+                bpf_map_delete_elem(&map_block6, &src_ip6);
             }
             else if (iph)
             {
-                bpf_map_delete_elem(&map_ip_blacklist, &iph->saddr);
+                bpf_map_delete_elem(&map_block, &iph->saddr);
             }
         }
         else
@@ -127,6 +125,21 @@ int xdp_prog_main(struct xdp_md *ctx)
         }
     }
 
+#ifdef ENABLE_IP_RANGE_DROP
+    if (iph && CheckIpRangeDrop(iph->saddr))
+    {
+#ifdef DO_STATS_ON_IP_RANGE_DROP_MAP
+        if (stats)
+        {
+            stats->dropped++;
+        }
+#endif
+
+        return XDP_DROP;
+    }
+#endif
+
+#ifdef ENABLE_FILTERS
     // Retrieve total packet length.
     u16 pkt_len = data_end - data;
 
@@ -267,7 +280,10 @@ int xdp_prog_main(struct xdp_md *ctx)
     {
         UpdateIpStats(&pps, &bps, iph->saddr, src_port, protocol, pkt_len, now);
     }
-    
+
+    int action = 0;
+    u64 block_time = 1;
+
     for (int i = 0; i < MAX_FILTERS; i++)
     {
         u32 key = i;
@@ -543,6 +559,7 @@ int xdp_prog_main(struct xdp_md *ctx)
 
         goto matched;
     }
+#endif
 
     if (stats)
     {
@@ -551,21 +568,22 @@ int xdp_prog_main(struct xdp_md *ctx)
             
     return XDP_PASS;
 
-    matched:
+#ifdef ENABLE_FILTERS
+matched:
     if (action == 0)
     {
-        // Before dropping, update the blacklist map.
+        // Before dropping, update the block map.
         if (block_time > 0)
         {
             u64 new_time = now + (block_time * NANO_TO_SEC);
             
             if (iph6)
             {
-                bpf_map_update_elem(&map_ip6_blacklist, &src_ip6, &new_time, BPF_ANY);
+                bpf_map_update_elem(&map_block6, &src_ip6, &new_time, BPF_ANY);
             }
             else if (iph)
             {
-                bpf_map_update_elem(&map_ip_blacklist, &iph->saddr, &new_time, BPF_ANY);
+                bpf_map_update_elem(&map_block, &iph->saddr, &new_time, BPF_ANY);
             }
         }
 
@@ -585,6 +603,7 @@ int xdp_prog_main(struct xdp_md *ctx)
     }
 
     return XDP_PASS;
+#endif
 }
 
 char _license[] SEC("license") = "GPL";

--- a/src/xdp/utils/helpers.c
+++ b/src/xdp/utils/helpers.c
@@ -1,5 +1,7 @@
 #include <xdp/utils/helpers.h>
 
+#include <xdp/utils/maps.h>
+
 /**
  * Checks if an IP is within a specific CIDR range.
  * 
@@ -13,3 +15,37 @@ static __always_inline int IsIpInRange(u32 src_ip, u32 net_ip, u8 cidr)
 {
     return !((src_ip ^ net_ip) & htonl(0xFFFFFFFFu << (32 - cidr)));
 }
+
+#ifdef ENABLE_IP_RANGE_DROP
+/**
+ * Checks if the IP is in the IP range drop map.
+ * 
+ * @param ip The IP address.
+ * 
+ * @return 1 on yes or 0 on no.
+ */
+static __always_inline int CheckIpRangeDrop(u32 ip)
+{
+    LpmTrieKey key =
+    {
+        .prefix_len = 32,
+        .data = ip
+    };
+
+    u64 *lookup = bpf_map_lookup_elem(&map_range_drop, &key);
+
+    if (lookup)
+    {
+        u32 bit_mask = *lookup >> 32;
+        u32 prefix = *lookup & 0xFFFFFFFF;
+
+        // Check if matched.
+        if ((ip & bit_mask) == prefix)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+#endif

--- a/src/xdp/utils/helpers.h
+++ b/src/xdp/utils/helpers.h
@@ -34,6 +34,10 @@
 
 static __always_inline int IsIpInRange(u32 src_ip, u32 net_ip, u8 cidr);
 
+#ifdef ENABLE_IP_RANGE_DROP
+static __always_inline int CheckIpRangeDrop(u32 ip);
+#endif
+
 // The source file is included directly below instead of compiled and linked as an object because when linking, there is no guarantee the compiler will inline the function (which is crucial for performance).
 // I'd prefer not to include the function logic inside of the header file.
 // More Info: https://stackoverflow.com/questions/24289599/always-inline-does-not-work-when-function-is-implemented-in-different-file

--- a/src/xdp/utils/logging.c
+++ b/src/xdp/utils/logging.c
@@ -4,6 +4,7 @@
 #include <xdp/utils/helpers.h>
 #include <xdp/utils/maps.h>
 
+#if defined(ENABLE_FILTERS) && defined(ENABLE_FILTER_LOGGING)
 /**
  * Logs a message to the filter ringbuffer map.
  * 
@@ -51,3 +52,4 @@ static __always_inline int LogFilterMsg(struct iphdr* iph, struct ipv6hdr* iph6,
 
     return 0;
 }
+#endif

--- a/src/xdp/utils/logging.h
+++ b/src/xdp/utils/logging.h
@@ -5,7 +5,9 @@
 #include <xdp/xdp_helpers.h>
 #include <xdp/prog_dispatcher.h>
 
+#if defined(ENABLE_FILTERS) && defined(ENABLE_FILTER_LOGGING)
 static __always_inline int LogFilterMsg(struct iphdr* iph, struct ipv6hdr* iph6, u16 src_port, u16 dst_port, u8 protocol, u64 now, u64 pps, u64 bps, int filter_id);
+#endif
 
 // The source file is included directly below instead of compiled and linked as an object because when linking, there is no guarantee the compiler will inline the function (which is crucial for performance).
 // I'd prefer not to include the function logic inside of the header file.

--- a/src/xdp/utils/maps.h
+++ b/src/xdp/utils/maps.h
@@ -8,19 +8,38 @@
 struct 
 {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __uint(max_entries, MAX_FILTERS);
-    __type(key, u32);
-    __type(value, filter_t);
-} map_filters SEC(".maps");
-
-struct 
-{
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __uint(max_entries, 1);
     __type(key, u32);
     __type(value, stats_t);
 } map_stats SEC(".maps");
 
+struct 
+{
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_TRACK_IPS);
+    __type(key, u32);
+    __type(value, u64);
+} map_block SEC(".maps");
+
+struct 
+{
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_TRACK_IPS);
+    __type(key, u128);
+    __type(value, u64);
+} map_block6 SEC(".maps");
+
+#ifdef ENABLE_IP_RANGE_DROP
+struct {
+    __uint(type, BPF_MAP_TYPE_LPM_TRIE);
+    __uint(max_entries, MAX_IP_RANGES);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+    __type(key, LpmTrieKey);
+    __type(value, u64);
+} map_range_drop SEC(".maps");
+#endif
+
+#ifdef ENABLE_FILTERS
 struct 
 {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
@@ -37,14 +56,6 @@ struct
 {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __uint(max_entries, MAX_TRACK_IPS);
-    __type(key, u32);
-    __type(value, u64);
-} map_ip_blacklist SEC(".maps");
-
-struct 
-{
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_TRACK_IPS);
 #ifdef USE_FLOW_RL
     __type(key, flow6_t);
 #else
@@ -55,11 +66,11 @@ struct
 
 struct 
 {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_TRACK_IPS);
-    __type(key, u128);
-    __type(value, u64);
-} map_ip6_blacklist SEC(".maps");
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, MAX_FILTERS);
+    __type(key, u32);
+    __type(value, filter_t);
+} map_filters SEC(".maps");
 
 #ifdef ENABLE_FILTER_LOGGING
 struct
@@ -67,4 +78,5 @@ struct
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 1 << 16);
 } map_filter_log SEC(".maps");
+#endif
 #endif

--- a/src/xdp/utils/rl.c
+++ b/src/xdp/utils/rl.c
@@ -1,5 +1,6 @@
 #include <xdp/utils/rl.h>
 
+#ifdef ENABLE_FILTERS
 /**
  * Updates IPv4 client stats.
  * 
@@ -129,3 +130,4 @@ static __always_inline void UpdateIp6Stats(u64 *pps, u64 *bps, u128 *ip, u16 por
 #endif
     }
 }
+#endif

--- a/src/xdp/utils/rl.h
+++ b/src/xdp/utils/rl.h
@@ -6,8 +6,10 @@
 
 #include <xdp/utils/maps.h>
 
+#ifdef ENABLE_FILTERS
 static __always_inline void UpdateIpStats(u64 *pps, u64 *bps, u32 ip, u16 port, u8 protocol, u16 pkt_len, u64 now);
 static __always_inline void UpdateIp6Stats(u64 *pps, u64 *bps, u128 *ip, u16 port, u8 protocol, u16 pkt_len, u64 now);
+#endif
 
 // The source file is included directly below instead of compiled and linked as an object because when linking, there is no guarantee the compiler will inline the function (which is crucial for performance).
 // I'd prefer not to include the function logic inside of the header file.


### PR DESCRIPTION
This PR introduces the option to pin the firewall's main BPF maps (dynamic filters, block map, and IP range dropping) to the file system. With this change, I've created two utilities, `xdpfw-add` and `xdpfw-del`. These utilities are used to add or delete dynamic filters, IP ranges from the drop list, and source IPs from the block list.

Additionally, new functionality that allows you to drop IP ranges (CIDR-based) has been added, but disabled by default. I've also made each core feature (dynamic filters, IP range dropping, and source IP blocking) modular so a user can enable or disable them if needed for better performance.

Other than the above, I've had to rewrite a lot of code and also revamped the README in an effort to make it more organized (still a work-in-progress).