### PR TITLE
Single Port Range Support With Dynamic Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ You may additionally specified TCP header options for a filter rule which start 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | tcp_enabled | bool | `false` | Whether to enable TCP on this filter rule. |
-| tcp_sport | int | `NULL` | The TCP source port to match. |
-| tcp_dport | int | `NULL` | The TCP destination port to match. |
+| tcp_sport | int \| string | `NULL` | The TCP source port to match with single range support (e.g., `"20-22"`). |
+| tcp_dport | int \| string | `NULL` | The TCP destination port to match with single range support (e.g., `"20-22"`). |
 | tcp_syn | bool | `false` | Matches if the TCP SYN flag is set. |
 | tcp_ack | bool | `false` | Matches if the TCP ACK flag is set. |
 | tcp_rst | bool | `false` | Matches if the TCP RST flag is set. |
@@ -211,8 +211,8 @@ You may additionally specified UDP header options for a filter rule which start 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | udp_enabled | bool | `false` | Whether to enable UDP on this filter rule. |
-| udp_sport | int | `NULL` | The UDP source port to match. |
-| udp_dport | int | `NULL` | The UDP destination port to match. |
+| udp_sport | int | `NULL` | The UDP source port to match with single range support (e.g., `"27000-27015"`). |
+| udp_dport | int | `NULL` | The UDP destination port to match with single range support (e.g., `"27000-27015"`). |
 
 #### ICMP Options
 You may additionally specified UDP header options for a filter rule which start with `icmp_`.
@@ -227,6 +227,7 @@ You may additionally specified UDP header options for a filter rule which start 
 * When a setting field inside of a filter rule is not set or if it's set to `-1` (or `NULL`), the default setting value will be used (see [`set_filter_defaults()`](https://github.com/gamemann/XDP-Firewall/blob/master/src/loader/utils/config.c#L1047)).
 * When a filter rule's setting is set, but doesn't match the packet, the program moves onto the next filter rule. Therefore, all of the filter rule's settings that are set must match the packet in order to perform the action specified. Think of it as something like `if src_ip == "10.50.0.3" and udp_dport == 27015: action`. 
 * As of right now, you can specify up to **60 total** dynamic filter rules. You may increase this limit by raising the `MAX_FILTERS` constant in the `src/common/config.h` [file](https://github.com/gamemann/XDP-Firewall/blob/master/src/common/config.h#L5) and then recompile the firewall. If you receive a BPF program too large error, this is due to BPF's limitations with complexity and jumps. You may try increasing BPF limitations manually or with a patch. If you want to do this, please read [this](https://github.com/gamemann/XDP-Proxy/tree/master/patches) from my XDP Proxy project.
+* At this time, each port value supports a single port range per filter rule. This is because adding support for multiple ports/port ranges would require an additional `for` loop which would make the BPF program larger and result in slower performance, etc.
 
 ### Runtime Example
 Here's a runtime config example.

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -33,11 +33,17 @@ struct filter_tcp
 {
     unsigned int enabled : 1;
 
-    unsigned int do_sport : 1;
-    u16 sport;
+    unsigned int do_sport_min : 1;
+    u16 sport_min;
 
-    unsigned int do_dport : 1;
-    u16 dport;
+    unsigned int do_sport_max : 1;
+    u16 sport_max;
+
+    unsigned int do_dport_min : 1;
+    u16 dport_min;
+
+    unsigned int do_dport_max : 1;
+    u16 dport_max;
 
     // TCP flags.
     unsigned int do_urg : 1;
@@ -69,11 +75,17 @@ struct filter_udp
 {
     unsigned int enabled : 1;
 
-    unsigned int do_sport : 1;
-    u16 sport;
+    unsigned int do_sport_min : 1;
+    u16 sport_min;
 
-    unsigned int do_dport : 1;
-    u16 dport;
+    unsigned int do_sport_max : 1;
+    u16 sport_max;
+
+    unsigned int do_dport_min : 1;
+    u16 dport_min;
+
+    unsigned int do_dport_max : 1;
+    u16 dport_max;
 } typedef filter_udp_t;
 
 struct filter_icmp

--- a/src/loader/utils/config.c
+++ b/src/loader/utils/config.c
@@ -505,19 +505,57 @@ int parse_cfg(config__t *cfg, const char* data, config_overrides_t* overrides)
             }
 
             // Source port.
-            int tcp_sport;
+            config_setting_t* tcp_sport = config_setting_lookup(filter_cfg, "tcp_sport");
 
-            if (config_setting_lookup_int(filter_cfg, "tcp_sport", &tcp_sport) == CONFIG_TRUE)
+            if (tcp_sport)
             {
-                filter->tcp.sport = tcp_sport;
+                int type = config_setting_type(tcp_sport);
+
+                if (type == CONFIG_TYPE_STRING)
+                {
+                    const char* val = config_setting_get_string(tcp_sport);
+
+                    if (val)
+                    {
+                        filter->tcp.sport = strdup(val);
+                    }
+                }
+                else if (type == CONFIG_TYPE_INT)
+                {
+                    int val = config_setting_get_int(tcp_sport);
+
+                    char val_str[12];
+                    snprintf(val_str, sizeof(val_str), "%d", val);
+
+                    filter->tcp.sport = strdup(val_str);
+                }
             }
 
             // Destination port.
-            int tcp_dport;
+            config_setting_t* tcp_dport = config_setting_lookup(filter_cfg, "tcp_dport");
 
-            if (config_setting_lookup_int(filter_cfg, "tcp_dport", &tcp_dport) == CONFIG_TRUE)
+            if (tcp_dport)
             {
-                filter->tcp.dport = tcp_dport;
+                int type = config_setting_type(tcp_dport);
+
+                if (type == CONFIG_TYPE_STRING)
+                {
+                    const char* val = config_setting_get_string(tcp_dport);
+
+                    if (val)
+                    {
+                        filter->tcp.dport = strdup(val);
+                    }
+                }
+                else if (type == CONFIG_TYPE_INT)
+                {
+                    int val = config_setting_get_int(tcp_dport);
+
+                    char val_str[12];
+                    snprintf(val_str, sizeof(val_str), "%d", val);
+
+                    filter->tcp.dport = strdup(val_str);
+                }
             }
 
             // URG flag.
@@ -595,21 +633,59 @@ int parse_cfg(config__t *cfg, const char* data, config_overrides_t* overrides)
             }
 
             // Source port.
-            int udp_sport;
+            config_setting_t* udp_sport = config_setting_lookup(filter_cfg, "udp_sport");
 
-            if (config_setting_lookup_int(filter_cfg, "udp_sport", &udp_sport) == CONFIG_TRUE)
+            if (udp_sport)
             {
-                filter->udp.sport = udp_sport;
+                int type = config_setting_type(udp_sport);
+
+                if (type == CONFIG_TYPE_STRING)
+                {
+                    const char* val = config_setting_get_string(udp_sport);
+
+                    if (val)
+                    {
+                        filter->udp.sport = strdup(val);
+                    }
+                }
+                else if (type == CONFIG_TYPE_INT)
+                {
+                    int val = config_setting_get_int(udp_sport);
+
+                    char val_str[12];
+                    snprintf(val_str, sizeof(val_str), "%d", val);
+
+                    filter->udp.sport = strdup(val_str);
+                }
             }
 
             // Destination port.
-            int udp_dport;
+            config_setting_t* udp_dport = config_setting_lookup(filter_cfg, "udp_dport");
 
-            if (config_setting_lookup_int(filter_cfg, "udp_dport", &udp_dport) == CONFIG_TRUE)
+            if (udp_dport)
             {
-                filter->udp.dport = udp_dport;
-            }
+                int type = config_setting_type(udp_dport);
 
+                if (type == CONFIG_TYPE_STRING)
+                {
+                    const char* val = config_setting_get_string(udp_dport);
+
+                    if (val)
+                    {
+                        filter->udp.dport = strdup(val);
+                    }
+                }
+                else if (type == CONFIG_TYPE_INT)
+                {
+                    int val = config_setting_get_int(udp_dport);
+
+                    char val_str[12];
+                    snprintf(val_str, sizeof(val_str), "%d", val);
+
+                    filter->udp.dport = strdup(val_str);
+                }
+            }
+            
             /* ICMP options */
 
             // Enabled.
@@ -884,17 +960,17 @@ int save_cfg(config__t* cfg, const char* file_path)
                 }
 
                 // Add TCP source port.
-                if (filter->tcp.sport > -1)
+                if (filter->tcp.sport)
                 {
-                    config_setting_t* tcp_sport = config_setting_add(filter_cfg, "tcp_sport", CONFIG_TYPE_INT);
-                    config_setting_set_int(tcp_sport, filter->tcp.sport);
+                    config_setting_t* tcp_sport = config_setting_add(filter_cfg, "tcp_sport", CONFIG_TYPE_STRING);
+                    config_setting_set_string(tcp_sport, filter->tcp.sport);
                 }
 
                 // Add TCP destination port.
-                if (filter->tcp.dport > -1)
+                if (filter->tcp.dport)
                 {
-                    config_setting_t* tcp_dport = config_setting_add(filter_cfg, "tcp_dport", CONFIG_TYPE_INT);
-                    config_setting_set_int(tcp_dport, filter->tcp.dport);
+                    config_setting_t* tcp_dport = config_setting_add(filter_cfg, "tcp_dport", CONFIG_TYPE_STRING);
+                    config_setting_set_string(tcp_dport, filter->tcp.dport);
                 }
 
                 // Add TCP URG flag.
@@ -961,17 +1037,17 @@ int save_cfg(config__t* cfg, const char* file_path)
                 }
 
                 // Add UDP source port.
-                if (filter->udp.sport > -1)
+                if (filter->udp.sport)
                 {
-                    config_setting_t* udp_sport = config_setting_add(filter_cfg, "udp_sport", CONFIG_TYPE_INT);
-                    config_setting_set_int(udp_sport, filter->udp.sport);
+                    config_setting_t* udp_sport = config_setting_add(filter_cfg, "udp_sport", CONFIG_TYPE_STRING);
+                    config_setting_set_string(udp_sport, filter->udp.sport);
                 }
 
                 // Add UDP destination port.
-                if (filter->udp.dport > -1)
+                if (filter->udp.dport)
                 {
-                    config_setting_t* udp_dport = config_setting_add(filter_cfg, "udp_dport", CONFIG_TYPE_INT);
-                    config_setting_set_int(udp_dport, filter->udp.dport);
+                    config_setting_t* udp_dport = config_setting_add(filter_cfg, "udp_dport", CONFIG_TYPE_STRING);
+                    config_setting_set_string(udp_dport, filter->udp.dport);
                 }
 
                 // Add ICMP enabled.
@@ -1095,8 +1171,19 @@ void set_filter_defaults(filter_rule_cfg_t* filter)
 
     filter->tcp.enabled = -1;
 
-    filter->tcp.sport = -1;
-    filter->tcp.dport = -1;
+    if (filter->tcp.sport)
+    {
+        free(filter->tcp.sport);
+
+        filter->tcp.sport = NULL;
+    }
+
+    if (filter->tcp.dport)
+    {
+        free(filter->tcp.dport);
+
+        filter->tcp.dport = NULL;
+    }
 
     filter->tcp.urg = -1;
     filter->tcp.ack = -1;
@@ -1108,8 +1195,20 @@ void set_filter_defaults(filter_rule_cfg_t* filter)
     filter->tcp.cwr = -1;
 
     filter->udp.enabled = -1;
-    filter->udp.sport = -1;
-    filter->udp.dport = -1;
+    
+    if (filter->udp.sport)
+    {
+        free(filter->udp.sport);
+
+        filter->udp.sport = NULL;
+    }
+
+    if (filter->udp.dport)
+    {
+        free(filter->udp.dport);
+
+        filter->udp.dport = NULL;
+    }
 
     filter->icmp.enabled = -1;
     filter->icmp.code = -1;
@@ -1254,8 +1353,8 @@ void print_filter(filter_rule_cfg_t* filter, int idx)
     // TCP Options.
     printf("\t\tTCP Options\n");
     printf("\t\t\tTCP Enabled => %d\n", filter->tcp.enabled);
-    printf("\t\t\tTCP Source Port => %d\n", filter->tcp.sport);
-    printf("\t\t\tTCP Destination Port => %d\n", filter->tcp.dport);
+    printf("\t\t\tTCP Source Port => %s\n", filter->tcp.sport);
+    printf("\t\t\tTCP Destination Port => %s\n", filter->tcp.dport);
     printf("\t\t\tTCP URG Flag => %d\n", filter->tcp.urg);
     printf("\t\t\tTCP ACK Flag => %d\n", filter->tcp.ack);
     printf("\t\t\tTCP RST Flag => %d\n", filter->tcp.rst);
@@ -1268,8 +1367,8 @@ void print_filter(filter_rule_cfg_t* filter, int idx)
     // UDP Options.
     printf("\t\tUDP Options\n");
     printf("\t\t\tUDP Enabled => %d\n", filter->udp.enabled);
-    printf("\t\t\tUDP Source Port => %d\n", filter->udp.sport);
-    printf("\t\t\tUDP Destination Port => %d\n\n", filter->udp.dport);
+    printf("\t\t\tUDP Source Port => %s\n", filter->udp.sport);
+    printf("\t\t\tUDP Destination Port => %s\n\n", filter->udp.dport);
 
     // ICMP Options.
     printf("\t\tICMP Options\n");

--- a/src/loader/utils/config.h
+++ b/src/loader/utils/config.h
@@ -34,8 +34,8 @@ struct filter_rule_filter_tcp
 {
     int enabled;
 
-    int sport;
-    int dport;
+    char* sport;
+    char* dport;
 
     int urg;
     int ack;
@@ -51,8 +51,8 @@ struct filter_rule_filter_udp
 {
     int enabled;
 
-    int sport;
-    int dport;
+    char* sport;
+    char* dport;
 } typedef filter_rule_filter_udp_t;
 
 struct filter_rule_filter_icmp

--- a/src/loader/utils/helpers.c
+++ b/src/loader/utils/helpers.c
@@ -122,3 +122,67 @@ u64 get_boot_nano_time()
 
     return sys.uptime * 1e9;
 }
+
+/**
+ * Parses a port range string and returns the minimum and maximum port.
+ * 
+ * @param range_str The port range string.
+ * 
+ * @return The port range as port_range_t type. Fields will be set to 0 on failure.
+ */
+port_range_t parse_port_range(const char* range_str)
+{
+    port_range_t ret = {0};
+
+    if (!range_str)
+    {
+        return ret;
+    }
+
+    // Copy range string.
+    char range_str_copy[24];
+    strncpy(range_str_copy, range_str, sizeof(range_str_copy) - 1);
+    range_str_copy[sizeof(range_str_copy) - 1] = '\0';
+
+    // First scan for port ranges with ":".
+    char* start = range_str_copy;
+    char* end = strchr(range_str_copy, '-');
+
+    if (!end)
+    {
+        end = strchr(range_str_copy, ':');
+    }
+
+    if (end)
+    {
+        *end = '\0';
+        end++;
+    }
+
+    char *end_ptr = NULL;
+
+    ret.min = strtol(start, &end_ptr, 10);
+
+    if (end_ptr == start || (*end_ptr != '\0' && !isspace((unsigned char)*end_ptr)))
+    {
+        return ret;
+    }
+
+    if (end)
+    {
+        ret.max = strtol(end, &end_ptr, 10);
+
+        if (end_ptr == end || (*end_ptr != '\0' && !isspace((unsigned char)*end_ptr)))
+        {
+            return ret;
+        }
+    }
+    else
+    {
+        ret.max = ret.min;
+    }
+
+    ret.success = 1;
+
+    return ret;
+}

--- a/src/loader/utils/helpers.h
+++ b/src/loader/utils/helpers.h
@@ -7,6 +7,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <string.h>
+#include <ctype.h>
+
 #include <sys/sysinfo.h>
 
 struct ip_range
@@ -14,6 +17,13 @@ struct ip_range
     u32 ip;
     u8 cidr;
 } typedef ip_range_t;
+
+struct port_range
+{
+    unsigned int success;
+    u16 min;
+    u16 max;
+} typedef port_range_t;
 
 extern int cont;
 
@@ -23,3 +33,4 @@ ip_range_t parse_ip_range(const char* ip);
 const char* get_protocol_str_by_id(int id);
 void print_tool_info();
 u64 get_boot_nano_time();
+port_range_t parse_port_range(const char* range_str);

--- a/src/loader/utils/xdp.c
+++ b/src/loader/utils/xdp.c
@@ -231,6 +231,11 @@ int update_filter(int map_filters, filter_rule_cfg_t* filter_cfg, int idx)
     filter_t filter = {0};
 
     filter.set = filter_cfg->set;
+
+    if (!filter_cfg->enabled)
+    {
+        return 0;
+    }
     
     if (filter_cfg->enabled > -1)
     {
@@ -340,18 +345,26 @@ int update_filter(int map_filters, filter_rule_cfg_t* filter_cfg, int idx)
         filter.tcp.enabled = filter_cfg->tcp.enabled;
     }
 
-    if (filter_cfg->tcp.sport > -1)
-    {
-        filter.tcp.do_sport = 1;
+    port_range_t tcp_src_port_range = parse_port_range(filter_cfg->tcp.sport);
 
-        filter.tcp.sport = htons((u16)filter_cfg->tcp.sport);
+    if (tcp_src_port_range.success)
+    {
+        filter.tcp.do_sport_min = 1;
+        filter.tcp.do_sport_max = 1;
+
+        filter.tcp.sport_min = htons(tcp_src_port_range.min);
+        filter.tcp.sport_max = htons(tcp_src_port_range.max);
     }
 
-    if (filter_cfg->tcp.dport > -1)
-    {
-        filter.tcp.do_dport = 1;
+    port_range_t tcp_dst_port_range = parse_port_range(filter_cfg->tcp.dport);
 
-        filter.tcp.dport = htons((u16)filter_cfg->tcp.dport);
+    if (tcp_dst_port_range.success)
+    {
+        filter.tcp.do_dport_min = 1;
+        filter.tcp.do_dport_max = 1;
+
+        filter.tcp.dport_min = htons(tcp_dst_port_range.min);
+        filter.tcp.dport_max = htons(tcp_dst_port_range.max);
     }
 
     if (filter_cfg->tcp.urg > -1)
@@ -415,18 +428,26 @@ int update_filter(int map_filters, filter_rule_cfg_t* filter_cfg, int idx)
         filter.udp.enabled = filter_cfg->udp.enabled;
     }
 
-    if (filter_cfg->udp.sport > -1)
-    {
-        filter.udp.do_sport = 1;
+    port_range_t udp_src_port_range = parse_port_range(filter_cfg->udp.sport);
 
-        filter.udp.sport = htons((u16)filter_cfg->udp.sport);
+    if (udp_src_port_range.success)
+    {
+        filter.udp.do_sport_min = 1;
+        filter.udp.do_sport_max = 1;
+
+        filter.udp.sport_min = htons(udp_src_port_range.min);
+        filter.udp.sport_max = htons(udp_src_port_range.max);
     }
 
-    if (filter_cfg->udp.dport > -1)
-    {
-        filter.udp.do_dport = 1;
+    port_range_t udp_dst_port_range = parse_port_range(filter_cfg->udp.dport);
 
-        filter.udp.dport = htons((u16)filter_cfg->udp.dport);
+    if (udp_dst_port_range.success)
+    {
+        filter.udp.do_dport_min = 1;
+        filter.udp.do_dport_max = 1;
+
+        filter.udp.dport_min = htons(udp_dst_port_range.min);
+        filter.udp.dport_max = htons(udp_dst_port_range.max);
     }
 
     if (filter_cfg->icmp.enabled > -1)

--- a/src/rule_add/prog.c
+++ b/src/rule_add/prog.c
@@ -39,8 +39,6 @@ int main(int argc, char *argv[])
     cli.tos = -1;
 
     cli.tcp_enabled = -1;
-    cli.tcp_sport = -1;
-    cli.tcp_dport = -1;
     cli.tcp_urg = -1;
     cli.tcp_ack = -1;
     cli.tcp_rst = -1;
@@ -51,8 +49,6 @@ int main(int argc, char *argv[])
     cli.tcp_cwr = -1;
 
     cli.udp_enabled = -1;
-    cli.udp_sport = -1;
-    cli.udp_dport = -1;
 
     cli.icmp_enabled = -1;
     cli.icmp_code = -1;
@@ -267,12 +263,12 @@ int main(int argc, char *argv[])
             new_filter.tcp.enabled = cli.tcp_enabled;
         }
 
-        if (cli.tcp_sport > -1)
+        if (cli.tcp_sport)
         {
             new_filter.tcp.sport = cli.tcp_sport;
         }
 
-        if (cli.tcp_dport > -1)
+        if (cli.tcp_dport)
         {
             new_filter.tcp.dport = cli.tcp_dport;
         }
@@ -322,12 +318,12 @@ int main(int argc, char *argv[])
             new_filter.udp.enabled = cli.udp_enabled;
         }
 
-        if (cli.udp_sport > -1)
+        if (cli.udp_sport)
         {
             new_filter.udp.sport = cli.udp_sport;
         }
 
-        if (cli.udp_dport > -1)
+        if (cli.udp_dport)
         {
             new_filter.udp.dport = cli.udp_dport;
         }

--- a/src/rule_add/utils/cli.c
+++ b/src/rule_add/utils/cli.c
@@ -185,12 +185,12 @@ void parse_cli(cli_t* cli, int argc, char* argv[])
                 break;
 
             case 12:
-                cli->tcp_sport = atoi(optarg);
+                cli->tcp_sport = optarg;
 
                 break;
 
             case 13:
-                cli->tcp_dport = atoi(optarg);
+                cli->tcp_dport = optarg;
 
                 break;
 
@@ -240,12 +240,12 @@ void parse_cli(cli_t* cli, int argc, char* argv[])
                 break;
 
             case 23:
-                cli->udp_sport = atoi(optarg);
+                cli->udp_sport = optarg;
 
                 break;
 
             case 24:
-                cli->udp_dport = atoi(optarg);
+                cli->udp_dport = optarg;
 
                 break;
 

--- a/src/rule_add/utils/cli.h
+++ b/src/rule_add/utils/cli.h
@@ -46,8 +46,8 @@ struct cli
     int tos;
 
     int tcp_enabled;
-    int tcp_sport;
-    int tcp_dport;
+    char* tcp_sport;
+    char* tcp_dport;
     int tcp_urg;
     int tcp_ack;
     int tcp_rst;
@@ -58,8 +58,8 @@ struct cli
     int tcp_cwr;
 
     int udp_enabled;
-    int udp_sport;
-    int udp_dport;
+    char* udp_sport;
+    char* udp_dport;
 
     int icmp_enabled;
     int icmp_code;

--- a/src/xdp/prog.c
+++ b/src/xdp/prog.c
@@ -446,14 +446,24 @@ int xdp_prog_main(struct xdp_md *ctx)
                 continue;
             }
 
-            // Source port.
-            if (filter->tcp.do_sport && filter->tcp.sport != tcph->source)
+            // Source port checks.
+            if (filter->tcp.do_sport_min && tcph->source < filter->tcp.sport_min)
             {
                 continue;
             }
 
-            // Destination port.
-            if (filter->tcp.do_dport && filter->tcp.dport != tcph->dest)
+            if (filter->tcp.do_sport_max && tcph->source > filter->tcp.sport_max)
+            {
+                continue;
+            }
+
+            // Destination port checks.
+            if (filter->tcp.do_dport_min && tcph->dest < filter->tcp.dport_min)
+            {
+                continue;
+            }
+
+            if (filter->tcp.do_dport_max && tcph->dest > filter->tcp.dport_max)
             {
                 continue;
             }
@@ -513,16 +523,25 @@ int xdp_prog_main(struct xdp_md *ctx)
                 continue;
             }
 
-            // Source port.
-            if (filter->udp.do_sport && filter->udp.sport != udph->source)
+            // Source port checks.
+            if (filter->udp.do_sport_min && udph->source < filter->udp.sport_min)
             {
                 continue;
             }
 
-            // Destination port.
-            if (filter->udp.do_dport && filter->udp.dport != udph->dest)
+            if (filter->udp.do_sport_max && udph->source > filter->udp.sport_max)
             {
+                continue;
+            }
 
+            // Destination port checks.
+            if (filter->udp.do_dport_min && udph->source < filter->udp.dport_min)
+            {
+                continue;
+            }
+
+            if (filter->udp.do_dport_max && udph->source > filter->udp.dport_max)
+            {
                 continue;
             }
         }


### PR DESCRIPTION
This PR adds support for a single port range when configuring TCP and UDP source and destination ports with dynamic filters.

The port range format looks like `x-y` or `x:y` (e.g., `20-22` or `27000:270015`).

At this time, only one port range is supported per port value. I believe this is best since if we do add support for multiple ports/port ranges, a `for` loop would be required and this would make the BPF program larger and slower.

Additionally, this change technically does decrease performance a bit with dynamic filters since an additional check is added, but I don't believe this is a big deal with dynamic filters at this time.