### PR TITLE
Add Flow And IP-Based Rate Limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ You may additionally specified UDP header options for a filter rule which start 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | udp_enabled | bool | `false` | Whether to enable UDP on this filter rule. |
-| udp_sport | int | `NULL` | The UDP source port to match with single range support (e.g., `"27000-27015"`). |
-| udp_dport | int | `NULL` | The UDP destination port to match with single range support (e.g., `"27000-27015"`). |
+| udp_sport | int \| string | `NULL` | The UDP source port to match with single range support (e.g., `"27000-27015"`). |
+| udp_dport | int \| string | `NULL` | The UDP destination port to match with single range support (e.g., `"27000-27015"`). |
 
 #### ICMP Options
 You may additionally specified UDP header options for a filter rule which start with `icmp_`.

--- a/README.md
+++ b/README.md
@@ -173,8 +173,10 @@ Here are more details on the layout of the runtime configuration.
 | log | bool | `false` | Whether to log packets that are matched. |
 | action | int | `1` | The value of `0` drops or blocks the packet while `1` allows/passes the packet through. |
 | block_time | int | `1` | The amount of seconds to block the source IP for if matched. |
-| pps | int64 | `NULL` | Matches if this threshold of packets per second is exceeded for a source IP. |
-| bps | int64 | `NULL` | Matches if this threshold of bytes per second is exceeded for a source IP. |
+| ip_pps | int64 | `NULL` | Matches if this threshold of packets per second is exceeded for a source IP. |
+| ip_bps | int64 | `NULL` | Matches if this threshold of bytes per second is exceeded for a source IP. |
+| flow_pps | int64 | `NULL` | Matches if this threshold of packets per second is exceeded for a source flow (IP and port). |
+| flow_bps | int64 | `NULL` | Matches if this threshold of bytes per second is exceeded for a source flow (IP and port). |
 
 #### IP Options
 | Name | Type | Default | Description |

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -15,10 +15,6 @@
 // Decrease this value if you receive errors related to the BPF program being too large.
 #define MAX_FILTERS 60
 
-// The maximum amount of IPs/flows to track stats for.
-// The higher this value is, the more memory that'll be used.
-#define MAX_TRACK_IPS 100000
-
 // Feel free to comment this out if you don't want the `blocked` entry on the stats map to be incremented every single time a packet is dropped from the source IP being on the blocked map.
 // Commenting this line out should increase performance when blocking malicious traffic.
 #define DO_STATS_ON_BLOCK_MAP
@@ -31,14 +27,26 @@
 // The same goes for IPv4, if there is no IPv4 source/destination IP addresses set, if an IPv6 address is set, it will ignore the filter.
 #define ALLOW_SINGLE_IP_V4_V6
 
-// If uncommented, rate limits for clients are determined using the source IP, port, and protocol instead of just the source IP.
-// This allows for more precise rate limits (connection-specific instead of a single source IP).
-// I decided not to include the destination IP/port because the source IP, port, and protocol should be represent a unique connection.
-#define USE_FLOW_RL
-
 // Enables filter logging through XDP.
 // If performance is a concern, it is best to disable this feature by commenting out the below line with //.
 #define ENABLE_FILTER_LOGGING
 
 // Maximum interfaces the firewall can attach to.
 #define MAX_INTERFACES 6
+
+// NOTE - If you're receiving a high volume of spoofed packets, it is recommended you disable rate limiting below.
+// This is because the PPS/BPS counters are updated for every packet and with a spoofed attack, the LRU map will recycle a lot of entries resulting in additional load on the CPU.
+// Enable source IP rate limiting.
+#define ENABLE_RL_IP
+
+// Enable source flow rate limiting.
+#define ENABLE_RL_FLOW
+
+// Maximum entries in source IP rate limit map.
+#define MAX_RL_IP 100000
+
+// Maximum entries in source flow rate limit map.
+#define MAX_RL_FLOW 100000
+
+// Maximum entries in block map.
+#define MAX_BLOCK 100000

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -108,11 +108,21 @@ struct filter
     u8 action;
     u16 block_time;
 
-    unsigned int do_pps : 1;
-    u64 pps;
+#ifdef ENABLE_RL_IP
+    unsigned int do_ip_pps : 1;
+    u64 ip_pps;
 
-    unsigned int do_bps : 1;
-    u64 bps;
+    unsigned int do_ip_bps : 1;
+    u64 ip_bps;
+#endif
+
+#ifdef ENABLE_RL_FLOW
+    unsigned int do_flow_pps : 1;
+    u64 flow_pps;
+
+    unsigned int do_flow_bps : 1;
+    u64 flow_bps;
+#endif
     
     filter_ip_t ip;
 
@@ -128,12 +138,12 @@ struct stats
     u64 passed;
 } typedef stats_t;
 
-struct ip_stats
+struct cl_stats
 {
     u64 pps;
     u64 bps;
     u64 next_update;
-} typedef ip_stats_t ;
+} typedef cl_stats_t;
 
 struct flow
 {
@@ -168,8 +178,11 @@ struct filter_log_event
 
     u8 protocol;
 
-    u64 pps;
-    u64 bps;
+    u64 ip_pps;
+    u64 ip_bps;
+
+    u64 flow_pps;
+    u64 flow_bps;
 } typedef filter_log_event_t;
 
 struct lpm_trie_key

--- a/src/loader/utils/config.c
+++ b/src/loader/utils/config.c
@@ -404,20 +404,36 @@ int parse_cfg(config__t *cfg, const char* data, config_overrides_t* overrides)
                 filter->block_time = block_time;
             }
 
-            // PPS (not required).
-            s64 pps;
+            // IP PPS (not required).
+            s64 ip_pps;
 
-            if (config_setting_lookup_int64(filter_cfg, "pps", &pps) == CONFIG_TRUE)
+            if (config_setting_lookup_int64(filter_cfg, "ip_pps", &ip_pps) == CONFIG_TRUE)
             {
-                filter->pps = pps;
+                filter->ip_pps = ip_pps;
             }
 
-            // BPS (not required).
-            s64 bps;
+            // IP BPS (not required).
+            s64 ip_bps;
 
-            if (config_setting_lookup_int64(filter_cfg, "bps", &bps) == CONFIG_TRUE)
+            if (config_setting_lookup_int64(filter_cfg, "ip_bps", &ip_bps) == CONFIG_TRUE)
             {
-                filter->bps = bps;
+                filter->ip_bps = ip_bps;
+            }
+
+            // Flow PPS (not required).
+            s64 flow_pps;
+
+            if (config_setting_lookup_int64(filter_cfg, "flow_pps", &flow_pps) == CONFIG_TRUE)
+            {
+                filter->flow_pps = flow_pps;
+            }
+
+            // Flow BPS (not required).
+            s64 flow_bps;
+
+            if (config_setting_lookup_int64(filter_cfg, "flow_bps", &flow_bps) == CONFIG_TRUE)
+            {
+                filter->flow_bps = flow_bps;
             }
 
             /* IP Options */
@@ -874,18 +890,32 @@ int save_cfg(config__t* cfg, const char* file_path)
                     config_setting_set_int(block_time, filter->block_time);
                 }
 
-                // Add PPS.
-                if (filter->pps > -1)
+                // Add IP PPS.
+                if (filter->ip_pps > -1)
                 {
-                    config_setting_t* pps = config_setting_add(filter_cfg, "pps", CONFIG_TYPE_INT64);
-                    config_setting_set_int64(pps, filter->pps);
+                    config_setting_t* pps = config_setting_add(filter_cfg, "ip_pps", CONFIG_TYPE_INT64);
+                    config_setting_set_int64(pps, filter->ip_pps);
                 }
 
-                // Add BPS.
-                if (filter->bps > -1)
+                // Add IP BPS.
+                if (filter->ip_bps > -1)
                 {
-                    config_setting_t* bps = config_setting_add(filter_cfg, "bps", CONFIG_TYPE_INT64);
-                    config_setting_set_int64(bps, filter->bps);
+                    config_setting_t* bps = config_setting_add(filter_cfg, "ip_bps", CONFIG_TYPE_INT64);
+                    config_setting_set_int64(bps, filter->ip_bps);
+                }
+
+                // Add flow PPS.
+                if (filter->flow_pps > -1)
+                {
+                    config_setting_t* pps = config_setting_add(filter_cfg, "flow_pps", CONFIG_TYPE_INT64);
+                    config_setting_set_int64(pps, filter->flow_pps);
+                }
+
+                // Add flow BPS.
+                if (filter->flow_bps > -1)
+                {
+                    config_setting_t* bps = config_setting_add(filter_cfg, "flow_bps", CONFIG_TYPE_INT64);
+                    config_setting_set_int64(bps, filter->flow_bps);
                 }
 
                 // Add source IPv4.
@@ -1130,8 +1160,10 @@ void set_filter_defaults(filter_rule_cfg_t* filter)
     filter->action = 1;
     filter->block_time = 1;
 
-    filter->pps = -1;
-    filter->bps = -1;
+    filter->ip_pps = -1;
+    filter->ip_bps = -1;
+    filter->flow_pps = -1;
+    filter->flow_bps = -1;
 
     if (filter->ip.src_ip)
     {
@@ -1299,8 +1331,11 @@ void print_filter(filter_rule_cfg_t* filter, int idx)
     printf("\t\tAction => %d (0 = Block, 1 = Allow).\n", filter->action);
     printf("\t\t\tBlock Time => %d\n\n", filter->block_time);
 
-    printf("\t\t\tPPS => %lld\n", filter->pps);
-    printf("\t\t\tBPS => %lld\n\n", filter->bps);
+    printf("\t\t\tIP PPS => %lld\n", filter->ip_pps);
+    printf("\t\t\tIP BPS => %lld\n", filter->ip_bps);
+
+    printf("\t\t\tFlow PPS => %lld\n", filter->flow_pps);
+    printf("\t\t\tFlow BPS => %lld\n", filter->flow_bps);
 
     // IP Options.
     printf("\t\tIP Options\n");

--- a/src/loader/utils/config.h
+++ b/src/loader/utils/config.h
@@ -72,8 +72,11 @@ struct filter_rule_cfg
     int action;
     int block_time;
 
-    s64 pps;
-    s64 bps;
+    s64 ip_pps;
+    s64 ip_bps;
+
+    s64 flow_pps;
+    s64 flow_bps;
 
     filter_rule_ip_opts_t ip;
     

--- a/src/loader/utils/logging.c
+++ b/src/loader/utils/logging.c
@@ -163,7 +163,7 @@ int hdl_filters_rb_event(void* ctx, void* data, size_t sz)
 
     const char* protocol_str = get_protocol_str_by_id(e->protocol);
 
-    log_msg(cfg, 0, 0, "[FILTER %d] %s %s packet '%s:%d' => '%s:%d' (PPS => %llu, BPS => %llu, Filter Block Time => %llu, length => %d)...", e->filter_id + 1, action, protocol_str, src_ip_str, htons(e->src_port), dst_ip_str, htons(e->dst_port), e->pps, e->bps, filter->block_time, e->length);
+    log_msg(cfg, 0, 0, "[FILTER %d] %s %s packet '%s:%d' => '%s:%d' (IP PPS => %llu, IP BPS => %llu, Flow PPS => %llu, Flow BPS => %llu Filter Block Time => %llu, length => %d)...", e->filter_id + 1, action, protocol_str, src_ip_str, htons(e->src_port), dst_ip_str, htons(e->dst_port), e->ip_pps, e->ip_bps, e->flow_pps, e->flow_bps, filter->block_time, e->length);
 
     return 0;
 }

--- a/src/loader/utils/xdp.c
+++ b/src/loader/utils/xdp.c
@@ -257,19 +257,37 @@ int update_filter(int map_filters, filter_rule_cfg_t* filter_cfg, int idx)
         filter.block_time = filter_cfg->block_time;
     }
 
-    if (filter_cfg->pps > -1)
+#ifdef ENABLE_RL_IP
+    if (filter_cfg->ip_pps > -1)
     {
-        filter.do_pps = 1;
+        filter.do_ip_pps = 1;
 
-        filter.pps = (u64) filter_cfg->pps;
+        filter.ip_pps = (u64) filter_cfg->ip_pps;
     }
 
-    if (filter_cfg->bps > -1)
+    if (filter_cfg->ip_bps > -1)
     {
-        filter.do_bps = 1;
+        filter.do_ip_bps = 1;
 
-        filter.bps = (u64) filter_cfg->bps;
+        filter.ip_bps = (u64) filter_cfg->ip_bps;
     }
+#endif
+
+#ifdef ENABLE_RL_FLOW
+    if (filter_cfg->flow_pps > -1)
+    {
+        filter.do_flow_pps = 1;
+
+        filter.flow_pps = (u64) filter_cfg->flow_pps;
+    }
+
+    if (filter_cfg->flow_bps > -1)
+    {
+        filter.do_flow_bps = 1;
+
+        filter.flow_bps = (u64) filter_cfg->flow_bps;
+    }
+#endif
 
     if (filter_cfg->ip.src_ip)
     {

--- a/src/rule_add/prog.c
+++ b/src/rule_add/prog.c
@@ -29,8 +29,11 @@ int main(int argc, char *argv[])
     cli.action = -1;
     cli.block_time = -1;
 
-    cli.pps = -1;
-    cli.bps = -1;
+    cli.ip_pps = -1;
+    cli.ip_bps = -1;
+
+    cli.flow_pps = -1;
+    cli.flow_bps = -1;
 
     cli.min_ttl = -1;
     cli.max_ttl = -1;
@@ -223,14 +226,24 @@ int main(int argc, char *argv[])
 
         // To Do: See if I can create a macro for below.
         // As long as the naming convention lines up, it should be easily possible.
-        if (cli.pps > -1)
+        if (cli.ip_pps > -1)
         {
-            new_filter.pps = cli.pps;
+            new_filter.ip_pps = cli.ip_pps;
         }
 
-        if (cli.bps > -1)
+        if (cli.ip_bps > -1)
         {
-            new_filter.bps = cli.bps;
+            new_filter.ip_bps = cli.ip_bps;
+        }
+
+        if (cli.flow_pps > -1)
+        {
+            new_filter.flow_pps = cli.flow_pps;
+        }
+
+        if (cli.flow_bps > -1)
+        {
+            new_filter.flow_bps = cli.flow_bps;
         }
 
         if (cli.min_ttl > -1)

--- a/src/rule_add/utils/cli.c
+++ b/src/rule_add/utils/cli.c
@@ -30,8 +30,11 @@ const struct option opts[] =
     { "max-len", required_argument, NULL, 7 },
     { "tos", required_argument, NULL, 8 },
 
-    { "pps", required_argument, NULL, 9 },
-    { "bps", required_argument, NULL, 10 },
+    { "ip-pps", required_argument, NULL, 9 },
+    { "ip-bps", required_argument, NULL, 10 },
+
+    { "ip-pps", required_argument, NULL, 32 },
+    { "ip-bps", required_argument, NULL, 33 },
 
     { "tcp", required_argument, NULL, 11 },
     { "tsport", required_argument, NULL, 12 },
@@ -170,12 +173,22 @@ void parse_cli(cli_t* cli, int argc, char* argv[])
                 break;
 
             case 9:
-                cli->pps = strtoll(optarg, NULL, 10);
+                cli->ip_pps = strtoll(optarg, NULL, 10);
 
                 break;
 
             case 10:
-                cli->bps = strtoll(optarg, NULL, 10);
+                cli->ip_bps = strtoll(optarg, NULL, 10);
+
+                break;
+
+            case 32:
+                cli->flow_pps = strtoll(optarg, NULL, 10);
+
+                break;
+
+            case 33:
+                cli->flow_bps = strtoll(optarg, NULL, 10);
 
                 break;
 

--- a/src/rule_add/utils/cli.h
+++ b/src/rule_add/utils/cli.h
@@ -36,8 +36,11 @@ struct cli
     char* src_ip6;
     char* dst_ip6;
 
-    s64 pps;
-    s64 bps;
+    s64 ip_pps;
+    s64 ip_bps;
+
+    s64 flow_pps;
+    s64 flow_bps;
 
     int min_ttl;
     int max_ttl;

--- a/src/xdp/prog.c
+++ b/src/xdp/prog.c
@@ -324,6 +324,7 @@ int xdp_prog_main(struct xdp_md *ctx)
     int action = 0;
     u64 block_time = 1;
 
+#pragma unroll
     for (int i = 0; i < MAX_FILTERS; i++)
     {
         u32 key = i;

--- a/src/xdp/prog.c
+++ b/src/xdp/prog.c
@@ -324,7 +324,7 @@ int xdp_prog_main(struct xdp_md *ctx)
     int action = 0;
     u64 block_time = 1;
 
-#pragma unroll
+#pragma unroll 30
     for (int i = 0; i < MAX_FILTERS; i++)
     {
         u32 key = i;

--- a/src/xdp/utils/logging.c
+++ b/src/xdp/utils/logging.c
@@ -14,14 +14,16 @@
  * @param dst_port The destination port.
  * @param protocol The protocol.
  * @param now The timestamp.
- * @param pps The current PPS rate.
- * @param bps The current BPS rate.
+ * @param ip_pps The current IP PPS rate.
+ * @param ip_bps The current IP BPS rate.
+ * @param flow_pps The current flow PPS rate.
+ * @param flow_bps The current flow BPS rate.
  * @param pkt_len The full packet length.
  * @param filter_id The filter ID that matched.
  * 
  * @return always 0
  */
-static __always_inline int log_filter_msg(struct iphdr* iph, struct ipv6hdr* iph6, u16 src_port, u16 dst_port, u8 protocol, u64 now, u64 pps, u64 bps, int pkt_len, int filter_id)
+static __always_inline int log_filter_msg(struct iphdr* iph, struct ipv6hdr* iph6, u16 src_port, u16 dst_port, u8 protocol, u64 now, u64 ip_pps, u64 ip_bps, u64 flow_pps, u64 flow_bps, int pkt_len, int filter_id)
 {
     filter_log_event_t* e = bpf_ringbuf_reserve(&map_filter_log, sizeof(*e), 0);
 
@@ -45,8 +47,11 @@ static __always_inline int log_filter_msg(struct iphdr* iph, struct ipv6hdr* iph
 
         e->protocol = protocol;
 
-        e->pps = pps;
-        e->bps = bps;
+        e->ip_pps = ip_pps;
+        e->ip_bps = ip_bps;
+
+        e->flow_pps = flow_pps;
+        e->flow_bps = flow_bps;
 
         e->length = pkt_len;
 

--- a/src/xdp/utils/logging.h
+++ b/src/xdp/utils/logging.h
@@ -6,7 +6,7 @@
 #include <xdp/prog_dispatcher.h>
 
 #if defined(ENABLE_FILTERS) && defined(ENABLE_FILTER_LOGGING)
-static __always_inline int log_filter_msg(struct iphdr* iph, struct ipv6hdr* iph6, u16 src_port, u16 dst_port, u8 protocol, u64 now, u64 pps, u64 bps, int pkt_len, int filter_id);
+static __always_inline int log_filter_msg(struct iphdr* iph, struct ipv6hdr* iph6, u16 src_port, u16 dst_port, u8 protocol, u64 now, u64 ip_pps, u64 ip_bps, u64 flow_pps, u64 flow_bps, int pkt_len, int filter_id);
 #endif
 
 // The source file is included directly below instead of compiled and linked as an object because when linking, there is no guarantee the compiler will inline the function (which is crucial for performance).

--- a/src/xdp/utils/maps.h
+++ b/src/xdp/utils/maps.h
@@ -16,7 +16,7 @@ struct
 struct 
 {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_TRACK_IPS);
+    __uint(max_entries, MAX_BLOCK);
     __type(key, u32);
     __type(value, u64);
 } map_block SEC(".maps");
@@ -24,7 +24,7 @@ struct
 struct 
 {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_TRACK_IPS);
+    __uint(max_entries, MAX_BLOCK);
     __type(key, u128);
     __type(value, u64);
 } map_block6 SEC(".maps");
@@ -41,29 +41,41 @@ struct
 #endif
 
 #ifdef ENABLE_FILTERS
+#ifdef ENABLE_RL_IP
 struct 
 {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_TRACK_IPS);
-#ifdef USE_FLOW_RL
-    __type(key, flow_t);
-#else
+    __uint(max_entries, MAX_RL_IP);
     __type(key, u32);
-#endif
-    __type(value, ip_stats_t);
+    __type(value, cl_stats_t);
 } map_ip_stats SEC(".maps");
 
 struct 
 {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_TRACK_IPS);
-#ifdef USE_FLOW_RL
-    __type(key, flow6_t);
-#else
+    __uint(max_entries, MAX_RL_IP);
     __type(key, u128);
-#endif
-    __type(value, ip_stats_t);
+    __type(value, cl_stats_t);
 } map_ip6_stats SEC(".maps");
+#endif
+
+#ifdef ENABLE_RL_FLOW
+struct 
+{
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_RL_FLOW);
+    __type(key, flow_t);
+    __type(value, cl_stats_t);
+} map_flow_stats SEC(".maps");
+
+struct 
+{
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_RL_FLOW);
+    __type(key, flow6_t);
+    __type(value, cl_stats_t);
+} map_flow6_stats SEC(".maps");
+#endif
 
 struct 
 {

--- a/src/xdp/utils/rl.h
+++ b/src/xdp/utils/rl.h
@@ -7,8 +7,10 @@
 #include <xdp/utils/maps.h>
 
 #ifdef ENABLE_FILTERS
-static __always_inline void update_ip_stats(u64 *pps, u64 *bps, u32 ip, u16 port, u8 protocol, u16 pkt_len, u64 now);
-static __always_inline void update_ip6_stats(u64 *pps, u64 *bps, u128 *ip, u16 port, u8 protocol, u16 pkt_len, u64 now);
+static __always_inline int update_ip_stats(u64 *pps, u64 *bps, u32 ip, u16 pkt_len, u64 now);
+static __always_inline int update_ip6_stats(u64 *pps, u64 *bps, u128 *ip, u16 pkt_len, u64 now);
+static __always_inline int update_flow_stats(u64 *pps, u64 *bps, u32 ip, u16 port, u8 protocol, u16 pkt_len, u64 now);
+static __always_inline int update_flow6_stats(u64 *pps, u64 *bps, u128 *ip, u16 port, u8 protocol, u16 pkt_len, u64 now);
 #endif
 
 // The source file is included directly below instead of compiled and linked as an object because when linking, there is no guarantee the compiler will inline the function (which is crucial for performance).


### PR DESCRIPTION
This PR adds both IP and flow-based rate limiting with dynamic filters. Beforehand, you could specify rate limits via the `pps` and `bps` settings, but the type of rate limiting (flow or IP-based) was determined at build time through a constant (`USE_RL_FLOW`).

Now, filter rules include both IP and flow-based settings: `flow_pps`, `flow_bps`, `ip_pps`, and `ip_bps`. The `pps` and `bps` settings are no longer supported.

Additionally, you can disable either type at build time inside of the `config.h` file which would increase performance if you're not using them.

I've also unrolled the main filters loop by 30 in the XDP program which saves some instructions and could potentially improve performance. I was running into an error stating the BPF program was too large (> 1 million instructions) after implementing the new rate limit system which is why I ended up doing this.

Lastly, there are a few more BPF maps created now due to the above change. Therefore, the XDP program will consume more memory, but you can always lower the maximum amount of entries per map by changing config constants in the `config.h` file.